### PR TITLE
Basic Navigation implementation

### DIFF
--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/PhoenixLiveViewPayload.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/PhoenixLiveViewPayload.kt
@@ -1,8 +1,8 @@
 package org.phoenixframework.liveview.data.dto
 
 data class PhoenixLiveViewPayload(
-    var dataPhxSession: String? = null,
-    var dataPhxStatic: String? = null,
-    var phxId: String? = null,
-    var _csrfToken: String? = null
+    val dataPhxSession: String? = null,
+    val dataPhxStatic: String? = null,
+    val phxId: String? = null,
+    val _csrfToken: String? = null
 )

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/service/ChannelService.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/service/ChannelService.kt
@@ -1,0 +1,66 @@
+package org.phoenixframework.liveview.data.service
+
+import android.util.Log
+import org.phoenixframework.Channel
+import org.phoenixframework.Message
+import org.phoenixframework.Payload
+import org.phoenixframework.liveview.data.dto.PhoenixLiveViewPayload
+
+class ChannelService(
+    private val socketService: SocketService
+) {
+    private var channel: Channel? = null
+
+    fun joinPhoenixChannel(
+        phxLiveViewPayload: PhoenixLiveViewPayload,
+        baseHttpUrl: String,
+        redirect: Boolean,
+        messageListener: (message: Message) -> Unit
+    ) {
+        channel = socketService.createChannel(phxLiveViewPayload, baseHttpUrl, redirect)?.apply {
+            join()
+                .receive("ok") { message: Message ->
+                    Log.d(TAG, "Channel::join::receive::ok")
+                    messageListener(message)
+                }
+                .receive("error") {
+                    Log.d(TAG, "Channel::join::receive::error->$it")
+                }
+                .receive("response") {
+                    Log.d(TAG, "Channel::join::receive::response->$it")
+                }
+
+            onMessage { message: Message ->
+                Log.d(TAG, "Channel::onMessage->$message")
+
+                when (message.event) {
+                    "phx_reply" -> {
+                        messageListener(message)
+                    }
+
+                    "diff" -> {
+                        messageListener(message)
+                    }
+
+                    "close" -> {
+                        channel?.leave()
+                    }
+                }
+                message
+            }
+        }
+    }
+
+    fun pushEvent(event: String, payload: Payload) {
+        Log.d(TAG, "pushEvent: event: $event, payload: $payload")
+        channel?.push(event, payload)
+    }
+
+    fun closeChannel() {
+        channel?.leave()
+    }
+
+    companion object {
+        private const val TAG = "ChannelService"
+    }
+}

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/service/SocketService.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/service/SocketService.kt
@@ -1,90 +1,55 @@
 package org.phoenixframework.liveview.data.service
 
 import android.util.Log
+import okhttp3.Call
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
+import okhttp3.Request
 import org.phoenixframework.Channel
-import org.phoenixframework.Message
-import org.phoenixframework.Payload
 import org.phoenixframework.Socket
 import org.phoenixframework.liveview.data.dto.PhoenixLiveViewPayload
 import java.util.UUID
 
-class SocketService(private val okHttpClient: OkHttpClient) {
+object SocketService {
     private var phxSocket: Socket? = null
-    private var channel: Channel? = null
+
     private val uuid: String = UUID.randomUUID().toString()
+
+    private val storedCookies = mutableListOf<Cookie>()
+
+    private val cookieJar = object : CookieJar {
+        override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+            storedCookies.addAll(cookies)
+        }
+
+        override fun loadForRequest(url: HttpUrl): List<Cookie> = storedCookies
+    }
+
+    private val okHttpClient: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .cookieJar(cookieJar)
+            .addInterceptor { chain ->
+                val original = chain.request()
+                val authorized = original.newBuilder().build()
+                chain.proceed(authorized);
+            }
+            .build()
+    }
+
+    val isConnected: Boolean
+        get() = phxSocket?.isConnected == true
 
     fun connectToLiveView(
         phxLiveViewPayload: PhoenixLiveViewPayload,
-        baseUrl: String,
-        socketBase: String,
-        messageListener: (message: Message) -> Unit
+        socketBaseUrl: String,
     ) {
         phxSocket?.disconnect()
         Log.d(TAG, "Connection to socket with params $phxLiveViewPayload")
-        setupPhxSocketConnection(phxLiveViewPayload, baseUrl = socketBase)
-
-        setupPhoenixChannel(
-            phxLiveViewPayload,
-            baseUrl = baseUrl,
-            messageListener = messageListener
-        )
+        setupPhxSocketConnection(phxLiveViewPayload, baseUrl = socketBaseUrl)
 
         phxSocket?.connect()
-    }
-
-    private fun setupPhoenixChannel(
-        phxLiveViewPayload: PhoenixLiveViewPayload,
-        baseUrl: String,
-        messageListener: (message: Message) -> Unit
-    ) {
-        val channelConnectionParams = mapOf(
-            "session" to phxLiveViewPayload.dataPhxSession,
-            "static" to phxLiveViewPayload.dataPhxStatic,
-            "url" to baseUrl,
-            "params" to
-                    mapOf(
-                        "_csrf_token" to phxLiveViewPayload._csrfToken,
-                        "_mounts" to 0,
-                        "client_id" to uuid,
-                        "_platform" to "jetpack"
-                    )
-        )
-
-        channel =
-            phxSocket
-                ?.channel(
-                    topic = "lv:${phxLiveViewPayload.phxId}",
-                    params = channelConnectionParams
-                )
-                ?.apply {
-                    join()
-                        .receive("ok") { message: Message ->
-                            Log.d(TAG, "Channel::join::receive::ok")
-                            messageListener(message)
-                        }
-                        .receive("error") {
-                            Log.d(TAG, "Channel::join::receive::error->$it")
-                        }
-                        .receive("response") {
-                            Log.d(TAG, "Channel::join::receive::response->$it")
-                        }
-
-                    onMessage { message: Message ->
-                        Log.d(TAG, "Channel::onMessage->$message")
-
-                        when (message.event) {
-                            "phx_reply" -> {
-                                messageListener(message)
-                            }
-
-                            "diff" -> {
-                                messageListener(message)
-                            }
-                        }
-                        message
-                    }
-                }
     }
 
     private fun setupPhxSocketConnection(
@@ -125,11 +90,33 @@ class SocketService(private val okHttpClient: OkHttpClient) {
                 }
     }
 
-    fun pushEvent(event: String, payload: Payload) {
-        channel?.push(event, payload)
+    fun createChannel(
+        phxLiveViewPayload: PhoenixLiveViewPayload,
+        baseHttpUrl: String,
+        redirect: Boolean,
+    ): Channel? {
+        val channelConnectionParams = mapOf(
+            "session" to phxLiveViewPayload.dataPhxSession,
+            "static" to phxLiveViewPayload.dataPhxStatic,
+            (if (redirect) "url" else "redirect") to baseHttpUrl,
+            "params" to
+                    mapOf(
+                        "_csrf_token" to phxLiveViewPayload._csrfToken,
+                        "_mounts" to 0,
+                        "client_id" to uuid,
+                        "_platform" to "jetpack"
+                    )
+        )
+        return phxSocket?.channel(
+            topic = "lv:${phxLiveViewPayload.phxId}",
+            params = channelConnectionParams
+        )
     }
 
-    companion object {
-        private const val TAG = "SocketService"
+    fun newHttpCall(url: String): Call {
+        val request = Request.Builder().url(url).get().build()
+        return okHttpClient.newCall(request)
     }
+
+    private const val TAG = "SocketService"
 }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/di/CommunicationModule.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/di/CommunicationModule.kt
@@ -1,0 +1,2 @@
+package org.phoenixframework.liveview.di
+

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/LiveViewCoordinator.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/LiveViewCoordinator.kt
@@ -302,7 +302,6 @@ class LiveViewCoordinator(
         // TODO As soon Core implement the new diff mechanism, this approach should be re-evaluated.
         fun getNodeState(composableTreeNode: ComposableTreeNode?): StateFlow<ComposableTreeNode?> {
             val key = stateKey(composableTreeNode?.screenId, composableTreeNode?.refId)
-            Log.d(TAG, key)
             if (!stateMap.containsKey(key)) {
                 stateMap[key] = MutableStateFlow(composableTreeNode)
             }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/LiveViewCoordinator.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/LiveViewCoordinator.kt
@@ -23,28 +23,55 @@ import org.phoenixframework.liveview.lib.NodeRef
 import java.net.ConnectException
 import java.util.Stack
 
-class LiveViewCoordinator(url: String) : ViewModel() {
-    private var doc: Document = Document()
-    private val repository: Repository = Repository(baseUrl = url)
+class LiveViewCoordinator(
+    private val screenId: String,
+    private val httpBaseUrl: String,
+    private val wsBaseUrl: String,
+    private val onNavigate: (String) -> Unit,
+) : ViewModel() {
+    private val repository: Repository = Repository(httpBaseUrl, wsBaseUrl)
+
+    private var document: Document = Document()
     private var lastRenderedMap: Map<String, Any?> = emptyMap()
+    private var reconnect = false
 
-    init {
-        connectToLiveViewMessageStream()
-    }
-
+    //TODO Is this stack necessary?
     private val _backStack = MutableStateFlow<Stack<ComposableTreeNode>>(Stack())
     val backStack = _backStack.asStateFlow()
 
-    private fun connectToLiveViewMessageStream() {
+    fun joinChannel() {
         viewModelScope.launch(Dispatchers.IO) {
-            repository.connect().catch { cause: Throwable -> getDomFromThrowable(cause) }.buffer()
+            if (!repository.isSocketConnected) {
+                repository.connectToLiveViewSocket()
+            }
+            repository.joinChannel(reconnect)
+                .catch { cause: Throwable -> getDomFromThrowable(cause) }
+                .buffer()
                 .collect { message ->
+                    Log.d(TAG, "message: $message")
                     when {
+                        message.payload.containsKey("live_redirect") -> handleRedirect(message)
+
                         message.payload.containsKey("rendered") -> handleRenderedMessage(message)
 
-                        message.payload.containsKey("diff") -> handleDiffMessage(message)
+                        message.payload.containsKey("diff") ||
+                                message.event == "diff" -> handleDiffMessage(message)
                     }
                 }
+
+        }.invokeOnCompletion {
+            Log.d(TAG, "Channel Flow Job completed url: $httpBaseUrl | wsUrl: $wsBaseUrl")
+        }
+    }
+
+    private fun handleRedirect(message: Message) {
+        Log.d(TAG, message.toString())
+        message.payload["live_redirect"]?.let { inputMap ->
+            val redirectMap: Map<String, Any?> = inputMap as Map<String, Any?>
+            Log.d(TAG, "kind->${redirectMap["kind"]} | to->${redirectMap["to"]}")
+            viewModelScope.launch(Dispatchers.Main) {
+                onNavigate(redirectMap["to"].toString())
+            }
         }
     }
 
@@ -58,7 +85,11 @@ class LiveViewCoordinator(url: String) : ViewModel() {
 
     private fun handleDiffMessage(message: Message) {
         val newMessage = lastRenderedMap.toMutableMap()
-        val diffDict = message.payload["diff"] as Map<String, Any>
+        val diffDict =
+            if (message.payload.containsKey("diff"))
+                message.payload["diff"] as Map<String, Any>
+            else
+                message.payload
         diffDict.forEach { (key, value) ->
             newMessage[key] = value
         }
@@ -83,9 +114,9 @@ class LiveViewCoordinator(url: String) : ViewModel() {
     }
 
     private fun parseTemplate(s: String, reRender: Boolean) {
-        val currentDom = ComposableTreeNode(0, null, null)
+        val currentDom = ComposableTreeNode(screenId, 0, null, null)
         val parsedDocument = Document.parse(s)
-        doc.merge(parsedDocument, object : Document.Companion.Handler() {
+        document.merge(parsedDocument, object : Document.Companion.Handler() {
             override fun onHandle(
                 context: Document,
                 changeType: Document.Companion.ChangeType,
@@ -141,10 +172,11 @@ class LiveViewCoordinator(url: String) : ViewModel() {
             is Node.Element -> {
                 val childNodeRefs = document.getChildren(nodeRef)
                 val composableTreeNode = ComposableNodeFactory.buildComposableTreeNode(
+                    screenId = screenId,
                     nodeRef = nodeRef,
                     element = CoreNodeElement.fromNodeElement(node),
                     children = childNodeRefs.map { childNodeRef ->
-                        CoreNodeElement.fromNodeElement(doc.getNode(nodeRef = childNodeRef))
+                        CoreNodeElement.fromNodeElement(this.document.getNode(nodeRef = childNodeRef))
                     },
                 )
                 parent?.addNode(composableTreeNode)
@@ -168,13 +200,9 @@ class LiveViewCoordinator(url: String) : ViewModel() {
         }
     }
 
-    fun pushEvent(type: String, event: String, value: Any, target: Int? = null) {
-        repository.pushEvent(type, event, value, target)
-    }
-
     private fun getDomFromThrowable(cause: Throwable) {
         val errorHtml = when (cause) {
-            is ConnectException -> {//4e0116c
+            is ConnectException -> {
                 """
                 <Column>
                     <Text width='fill' padding='16'>${cause.message}</Text>
@@ -225,10 +253,14 @@ class LiveViewCoordinator(url: String) : ViewModel() {
     ) {
         val composableTreeNode = findNodeById(nodeRef.ref)
         Log.d(TAG, "notifyNodeChange: $composableTreeNode - ${composableTreeNode?.text}")
-        stateMap[nodeRef.ref]?.update {
+        if (composableTreeNode == null) {
+            return
+        }
+        stateMap[stateKey(screenId, nodeRef.ref)]?.update {
+            Log.d(TAG, "notifyNodeChange: Node found!")
             val node = document.getNode(nodeRef)
             val children = document.getChildren(nodeRef)
-            composableTreeNode?.copy(
+            composableTreeNode.copy(
                 node = CoreNodeElement.fromNodeElement(node),
                 childrenNodes = children.map {
                     CoreNodeElement.fromNodeElement(
@@ -242,24 +274,35 @@ class LiveViewCoordinator(url: String) : ViewModel() {
         }
     }
 
+    fun leaveChannel() {
+        repository.closeChannel()
+    }
+
+    fun pushEvent(type: String, event: String, value: Any, target: Int? = null) {
+        Log.d(TAG, "pushEvent: type: $type, event: $event, value: $value, target: $target")
+        repository.pushEvent(type, event, value, target)
+    }
+
     override fun onCleared() {
         super.onCleared()
-        stateMap.clear()
+        repository.closeChannel()
     }
 
     companion object {
         const val TAG = "VM"
 
-        val stateMap = mutableMapOf<Int, MutableStateFlow<ComposableTreeNode?>>()
+        private val stateMap = mutableMapOf<String, MutableStateFlow<ComposableTreeNode?>>()
+
+        private fun stateKey(screenId: String?, refId: Int?) = "$screenId---$refId"
 
         // TODO This is a temporary solution for node updates.
         // TODO As soon Core implement the new diff mechanism, this approach should be re-evaluated.
         fun getNodeState(composableTreeNode: ComposableTreeNode?): StateFlow<ComposableTreeNode?> {
-            val refId = composableTreeNode?.refId
-            if (refId != null && !stateMap.containsKey(refId)) {
-                stateMap[refId] = MutableStateFlow(composableTreeNode)
+            val key = stateKey(composableTreeNode?.screenId, composableTreeNode?.refId)
+            if (!stateMap.containsKey(key)) {
+                stateMap[key] = MutableStateFlow(composableTreeNode)
             }
-            return stateMap[refId]!!
+            return stateMap[key]!!
         }
     }
 }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
@@ -58,9 +58,13 @@ object ComposableNodeFactory {
      * @return a `ComposableTreeNode` object based on the input `Element` object
      */
     fun buildComposableTreeNode(
-        nodeRef: NodeRef, element: CoreNodeElement, children: List<CoreNodeElement>,
+        screenId: String,
+        nodeRef: NodeRef,
+        element: CoreNodeElement,
+        children: List<CoreNodeElement>,
     ): ComposableTreeNode {
         return ComposableTreeNode(
+            screenId,
             nodeRef.ref,
             element,
             children.toImmutableList(),

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableTree.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableTree.kt
@@ -6,6 +6,7 @@ import org.phoenixframework.liveview.data.core.CoreNodeElement
 import java.util.UUID
 
 data class ComposableTreeNode(
+    val screenId: String,
     var refId: Int,
     val node: CoreNodeElement?,
     val childrenNodes: ImmutableList<CoreNodeElement>?,

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/LiveView.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/LiveView.kt
@@ -1,5 +1,6 @@
 package org.phoenixframework.liveview.ui.phx_components
 
+import android.net.Uri
 import android.util.Log
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.MaterialTheme
@@ -8,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavBackStackEntry
@@ -24,11 +26,14 @@ private const val ARG_ROUTE = "route"
 
 @Composable
 fun LiveView(
-    httpBaseUrl: String,
-    wsBaseUrl: String
+    url: String,
 ) {
+    // The WebSocket URL is the same of the HTTP URL, so we just copy the HTTP URL changing the schema (protocol)
+    val webSocketBaseUrl = remember(url) {
+        Uri.parse(url).buildUpon().scheme("ws").build().toString()
+    }
+
     LiveViewTestTheme {
-        // A surface container using the 'background' color from the theme
         Surface(
             modifier = Modifier.fillMaxSize(),
             color = MaterialTheme.colors.background
@@ -43,8 +48,8 @@ fun LiveView(
                 ) { backStackEntry ->
                     NavDestination(
                         backStackEntry = backStackEntry,
-                        httpBaseUrl = httpBaseUrl,
-                        wsBaseUrl = wsBaseUrl,
+                        httpBaseUrl = url,
+                        wsBaseUrl = webSocketBaseUrl,
                         onNavigate = { route ->
                             navController.navigate("$PHX_LIVE_VIEW_ROUTE?$ARG_ROUTE=$route")
                         }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/LiveView.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/LiveView.kt
@@ -69,7 +69,6 @@ private fun NavDestination(
         viewModelStoreOwner = backStackEntry,
         initializer = {
             LiveViewCoordinator(
-                screenId = route ?: "/",
                 httpBaseUrl = httpUrl,
                 wsBaseUrl = webSocketUrl,
                 onNavigate = onNavigate

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/LiveView.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/LiveView.kt
@@ -1,30 +1,95 @@
 package org.phoenixframework.liveview.ui.phx_components
 
+import android.util.Log
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import org.phoenixframework.liveview.domain.LiveViewCoordinator
 import org.phoenixframework.liveview.ui.theme.LiveViewTestTheme
 
+private const val TAG = "LiveView"
+private const val PHX_LIVE_VIEW_ROUTE = "phxLiveView"
+private const val ARG_ROUTE = "route"
+
 @Composable
-fun LiveView(liveViewCoordinator: LiveViewCoordinator) {
-    val state by liveViewCoordinator.backStack.collectAsState()
+fun LiveView(
+    httpBaseUrl: String,
+    wsBaseUrl: String
+) {
     LiveViewTestTheme {
         // A surface container using the 'background' color from the theme
         Surface(
             modifier = Modifier.fillMaxSize(),
             color = MaterialTheme.colors.background
         ) {
-            if (state.isNotEmpty()) {
-                PhxLiveView(
-                    composableNode = state.peek().children.first(),
-                    pushEvent = liveViewCoordinator::pushEvent
-                )
+            val navController = rememberNavController()
+            NavHost(navController = navController, startDestination = PHX_LIVE_VIEW_ROUTE) {
+                composable(
+                    route = "$PHX_LIVE_VIEW_ROUTE?$ARG_ROUTE={$ARG_ROUTE}",
+                    arguments = listOf(navArgument(ARG_ROUTE) {
+                        nullable = true
+                    })
+                ) { backStackEntry ->
+                    NavDestination(
+                        backStackEntry = backStackEntry,
+                        httpBaseUrl = httpBaseUrl,
+                        wsBaseUrl = wsBaseUrl,
+                        onNavigate = { route ->
+                            navController.navigate("$PHX_LIVE_VIEW_ROUTE?$ARG_ROUTE=$route")
+                        }
+                    )
+                }
             }
+        }
+    }
+}
+
+@Composable
+private fun NavDestination(
+    backStackEntry: NavBackStackEntry,
+    httpBaseUrl: String,
+    wsBaseUrl: String,
+    onNavigate: (String) -> Unit
+) {
+    val route = backStackEntry.arguments?.getString("route")
+    val httpUrl = if (route == null) httpBaseUrl else "$httpBaseUrl$route"
+    val webSocketUrl = if (route == null) wsBaseUrl else "$wsBaseUrl$route"
+    val liveViewCoordinator = viewModel(
+        viewModelStoreOwner = backStackEntry,
+        initializer = {
+            LiveViewCoordinator(
+                screenId = route ?: "/",
+                httpBaseUrl = httpUrl,
+                wsBaseUrl = webSocketUrl,
+                onNavigate = onNavigate
+            )
+        }
+    )
+    val state by liveViewCoordinator.backStack.collectAsState()
+    if (state.isNotEmpty()) {
+        PhxLiveView(
+            composableNode = state.peek().children.first(),
+            pushEvent = liveViewCoordinator::pushEvent
+        )
+    }
+
+    DisposableEffect(route) {
+        Log.d(TAG, "DisposableEffect::body->$route")
+        liveViewCoordinator.joinChannel()
+        onDispose {
+            Log.d(TAG, "DisposableEffect::onDispose->$route")
+            liveViewCoordinator.leaveChannel()
         }
     }
 }

--- a/liveviewsample/src/main/java/com/dockyard/android/liveviewsample/ui/MainActivity.kt
+++ b/liveviewsample/src/main/java/com/dockyard/android/liveviewsample/ui/MainActivity.kt
@@ -10,10 +10,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
-            LiveView(
-                "http://10.0.2.2:4000",
-                "ws://10.0.2.2:4000"
-            )
+            LiveView(url = "http://10.0.2.2:4000")
         }
     }
 }

--- a/liveviewsample/src/main/java/com/dockyard/android/liveviewsample/ui/MainActivity.kt
+++ b/liveviewsample/src/main/java/com/dockyard/android/liveviewsample/ui/MainActivity.kt
@@ -3,8 +3,6 @@ package com.dockyard.android.liveviewsample.ui
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.lifecycle.viewmodel.compose.viewModel
-import org.phoenixframework.liveview.domain.LiveViewCoordinator
 import org.phoenixframework.liveview.ui.phx_components.LiveView
 
 class MainActivity : ComponentActivity() {
@@ -13,7 +11,8 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             LiveView(
-                viewModel(initializer = { LiveViewCoordinator(url = "http://10.0.2.2:4000") })
+                "http://10.0.2.2:4000",
+                "ws://10.0.2.2:4000"
             )
         }
     }


### PR DESCRIPTION
This PR includes a simple implementation of opening a new screen on top of the previous one. 

In LiveView, the basic usage is define a function like below:
```
  def handle_event("navigate", _params, socket) do
    {:noreply, push_navigate(socket, to: "/counter")}
  end
```
and call it from the client, like this:
```
<Button phx-click="navigate">
  <Text>Go to counter</Text>
</Button>
```

<img src="https://github.com/liveview-native/liveview-client-jetpack/assets/20464075/0377c5cc-2fa4-4e7f-a251-6e91ce7aab0a" width=300 />

This PR includes a simplified usage of the `LiveView` composable. Now, you just need to pass the URL:
```
class MainActivity : ComponentActivity() {
    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)

        setContent {
            LiveView(url = "http://10.0.2.2:4000")
        }
    }
}
```
But it's still necessary to host the `*.aar` file somewhere (maybe on Jitpack) in order to use the library in a separate project.