### PR TITLE
Integration with Core Jetpack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ buildscript {
         gson_version = '2.10.1'
         java_phoenix_client_version = '1.1.3'
         jsoup_version = '1.15.3'
+        kotlin_immutable_collections_version = '0.3.5'
         lifecyle_version = '2.6.1'
         liveview_native_core_jetpack_version = '0.1.0-pre-alpha-08'
         material_design_3_version = '1.1.2'

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ buildscript {
         gson_version = '2.10.1'
         java_phoenix_client_version = '1.1.3'
         jsoup_version = '1.15.3'
-        kotlin_immutable_collections_version = '0.3.5'
         lifecyle_version = '2.6.1'
         liveview_native_core_jetpack_version = '0.1.0-pre-alpha-08'
         material_design_3_version = '1.1.2'

--- a/liveview-android/build.gradle
+++ b/liveview-android/build.gradle
@@ -64,11 +64,11 @@ dependencies {
 
     api "com.github.dsrees:JavaPhoenixClient:$java_phoenix_client_version"
     api "com.google.guava:guava:$guava_version"
-    api "com.github.liveview-native:liveview-native-core-jetpack:$liveview_native_core_jetpack_version"
+    //api "com.github.liveview-native:liveview-native-core-jetpack:$liveview_native_core_jetpack_version"
+    api files("/Users/nelson.glauber/dockyard/code/liveview-native-core-jetpack/core/build/outputs/aar/core-debug.aar")
 
     api "org.apache.commons:commons-math3:$commons_math_version"
     api "org.apache.commons:commons-text:$commons_text_version"
-    api "org.jetbrains.kotlinx:kotlinx-collections-immutable:$kotlin_immutable_collections_version"
     api "org.jsoup:jsoup:$jsoup_version"
 
     api "io.coil-kt:coil:$coil_version"

--- a/liveview-android/build.gradle
+++ b/liveview-android/build.gradle
@@ -69,6 +69,7 @@ dependencies {
 
     api "org.apache.commons:commons-math3:$commons_math_version"
     api "org.apache.commons:commons-text:$commons_text_version"
+    api "org.jetbrains.kotlinx:kotlinx-collections-immutable:$kotlin_immutable_collections_version"
     api "org.jsoup:jsoup:$jsoup_version"
 
     api "io.coil-kt:coil:$coil_version"
@@ -79,4 +80,28 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:$ext_junit_version"
 
     testImplementation "junit:junit:$junit_version"
+
+
+}
+
+// ./gradlew assembleRelease -PcomposeCompilerReports=true
+// Run the command above in order to generate the compose stability diagnose report.
+// https://developer.android.com/jetpack/compose/performance/stability/diagnose
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions {
+        if (project.findProperty("composeCompilerReports") == "true") {
+            freeCompilerArgs += [
+                    "-P",
+                    "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" +
+                            project.buildDir.absolutePath + "/compose_compiler"
+            ]
+        }
+        if (project.findProperty("composeCompilerMetrics") == "true") {
+            freeCompilerArgs += [
+                    "-P",
+                    "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" +
+                            project.buildDir.absolutePath + "/compose_compiler"
+            ]
+        }
+    }
 }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/core/CoreAttribute.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/core/CoreAttribute.kt
@@ -1,13 +1,13 @@
 package org.phoenixframework.liveview.data.core
 
-import org.jetbrains.annotations.ApiStatus.Experimental
+import androidx.compose.runtime.Immutable
 import org.phoenixframework.liveview.lib.Attribute
 
 /**
  * This class is a copy of the `Attribute` class existing in Core-Jetpack.
  * It stores data from `Attribute` class in order to avoid to deal native objects.
  */
-@Experimental
+@Immutable
 data class CoreAttribute internal constructor(
     val name: String,
     val namespace: String,

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/core/CoreNodeElement.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/core/CoreNodeElement.kt
@@ -1,9 +1,6 @@
 package org.phoenixframework.liveview.data.core
 
 import androidx.compose.runtime.Immutable
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.toImmutableList
-import okhttp3.internal.immutableListOf
 import org.phoenixframework.liveview.lib.Node
 
 /**
@@ -14,8 +11,30 @@ import org.phoenixframework.liveview.lib.Node
 data class CoreNodeElement internal constructor(
     val tag: String,
     val namespace: String,
-    val attributes: ImmutableList<CoreAttribute>
+    val attributes: Array<CoreAttribute>
 ) {
+
+    // The hashCode and equals functions has an important role in terms of performance.
+    // They guarantee that a composable function will be called again (recomposed) or not.
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as CoreNodeElement
+
+        if (tag != other.tag) return false
+        if (namespace != other.namespace) return false
+        return attributes.contentDeepEquals(other.attributes)
+    }
+
+    override fun hashCode(): Int {
+        var result = tag.hashCode()
+        result = 31 * result + namespace.hashCode()
+        result = 31 * result + attributes.hashCode()
+        return result
+    }
+
     /**
      * Create a new instance of `CoreNodeElement` from an `Node` object.
      */
@@ -28,21 +47,21 @@ data class CoreNodeElement internal constructor(
                     CoreNodeElement(
                         node.tag,
                         node.namespace,
-                        node.attributes.map { CoreAttribute.fromAttribute(it) }.toImmutableList()
+                        node.attributes.map { CoreAttribute.fromAttribute(it) }.toTypedArray()
                     )
                 }
 
                 is Node.Root ->
-                    CoreNodeElement("", "", emptyList<CoreAttribute>().toImmutableList())
+                    CoreNodeElement("", "", emptyArray<CoreAttribute>())
 
                 is Node.Leaf ->
                     // A Leaf is considered an a Node element with a single attribute: text
                     CoreNodeElement(
                         "",
                         "",
-                        immutableListOf(
+                        arrayOf(
                             CoreAttribute(TEXT_ATTRIBUTE, "", node.value)
-                        ).toImmutableList()
+                        )
                     )
             }
         }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/core/CoreNodeElement.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/core/CoreNodeElement.kt
@@ -8,7 +8,7 @@ import org.phoenixframework.liveview.lib.Node
  * It stores data from `Node.Element` class in order to avoid to deal native objects.
  */
 @Experimental
-data class CoreNodeElement(
+data class CoreNodeElement internal constructor(
     val tag: String,
     val namespace: String,
     val attributes: List<CoreAttribute>
@@ -31,5 +31,18 @@ data class CoreNodeElement(
                     CoreNodeElement("", "", emptyList())
             }
         }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return super.equals(other) && attributes.toTypedArray().contentDeepEquals(
+            (other as CoreNodeElement).attributes.toTypedArray()
+        )
+    }
+
+    override fun hashCode(): Int {
+        var result = tag.hashCode()
+        result = 31 * result + namespace.hashCode()
+        result = 31 * result + attributes.hashCode()
+        return result
     }
 }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/core/CoreNodeElement.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/core/CoreNodeElement.kt
@@ -1,48 +1,50 @@
 package org.phoenixframework.liveview.data.core
 
-import org.jetbrains.annotations.ApiStatus.Experimental
+import androidx.compose.runtime.Immutable
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+import okhttp3.internal.immutableListOf
 import org.phoenixframework.liveview.lib.Node
 
 /**
  * This class is abstraction of  the `Node.Element` class existing in Core-Jetpack.
  * It stores data from `Node.Element` class in order to avoid to deal native objects.
  */
-@Experimental
+@Immutable
 data class CoreNodeElement internal constructor(
     val tag: String,
     val namespace: String,
-    val attributes: List<CoreAttribute>
+    val attributes: ImmutableList<CoreAttribute>
 ) {
     /**
      * Create a new instance of `CoreNodeElement` from an `Node` object.
      */
     companion object {
+        internal const val TEXT_ATTRIBUTE = "text"
+
         fun fromNodeElement(node: Node): CoreNodeElement {
             return when (node) {
                 is Node.Element -> {
                     CoreNodeElement(
                         node.tag,
                         node.namespace,
-                        node.attributes.map { CoreAttribute.fromAttribute(it) }
+                        node.attributes.map { CoreAttribute.fromAttribute(it) }.toImmutableList()
                     )
                 }
 
-                is Node.Root, is Node.Leaf ->
-                    CoreNodeElement("", "", emptyList())
+                is Node.Root ->
+                    CoreNodeElement("", "", emptyList<CoreAttribute>().toImmutableList())
+
+                is Node.Leaf ->
+                    // A Leaf is considered an a Node element with a single attribute: text
+                    CoreNodeElement(
+                        "",
+                        "",
+                        immutableListOf(
+                            CoreAttribute(TEXT_ATTRIBUTE, "", node.value)
+                        ).toImmutableList()
+                    )
             }
         }
-    }
-
-    override fun equals(other: Any?): Boolean {
-        return super.equals(other) && attributes.toTypedArray().contentDeepEquals(
-            (other as CoreNodeElement).attributes.toTypedArray()
-        )
-    }
-
-    override fun hashCode(): Int {
-        var result = tag.hashCode()
-        result = 31 * result + namespace.hashCode()
-        result = 31 * result + attributes.hashCode()
-        return result
     }
 }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/AsyncImageDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/AsyncImageDTO.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import org.phoenixframework.liveview.data.core.CoreAttribute
-import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.domain.base.ComposableBuilder
 import org.phoenixframework.liveview.domain.base.ComposableView
 import org.phoenixframework.liveview.domain.base.ComposableViewFactory
@@ -108,8 +107,7 @@ object AsyncImageDtoFactory : ComposableViewFactory<AsyncImageDTO, AsyncImageDTO
      * @return an `AsyncImageDTO` object based on the attributes and text of the input `Attributes` object
      */
     override fun buildComposableView(
-        attributes: List<CoreAttribute>,
-        children: List<CoreNodeElement>?,
+        attributes: Array<CoreAttribute>,
         pushEvent: PushEvent?,
     ): AsyncImageDTO = attributes.fold(
         AsyncImageDTO.Builder().imageUrl(attributes.find { it.name == "url" }?.value ?: "")

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/ButtonDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/ButtonDTO.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.toImmutableMap
 import org.phoenixframework.liveview.data.core.CoreAttribute
-import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.data.mappers.JsonParser
 import org.phoenixframework.liveview.domain.base.ComposableBuilder
 import org.phoenixframework.liveview.domain.base.ComposableView
@@ -181,8 +180,7 @@ object ButtonDtoFactory : ComposableViewFactory<ButtonDTO, ButtonDTO.Builder>() 
      * @return a `ButtonDTO` object based on the attributes of the input `Attributes` object
      **/
     override fun buildComposableView(
-        attributes: List<CoreAttribute>,
-        children: List<CoreNodeElement>?,
+        attributes: Array<CoreAttribute>,
         pushEvent: PushEvent?,
     ): ButtonDTO = attributes.fold(ButtonDTO.Builder()) { builder, attribute ->
         when (attribute.name) {

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/ButtonDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/ButtonDTO.kt
@@ -6,10 +6,13 @@ import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ButtonElevation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.toImmutableMap
 import org.phoenixframework.liveview.data.core.CoreAttribute
 import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.data.mappers.JsonParser
@@ -23,13 +26,14 @@ import org.phoenixframework.liveview.domain.factory.ComposableTreeNode
 import org.phoenixframework.liveview.ui.phx_components.PhxLiveView
 import org.phoenixframework.liveview.ui.theme.shapeFromString
 
+@Stable
 class ButtonDTO private constructor(builder: Builder) :
     ComposableView(modifier = builder.modifier) {
     private val onClick: () -> Unit = builder.onClick
     private val enabled: Boolean = builder.enabled
     private val shape: Shape? = builder.shape
-    private val colors: Map<String, String>? = builder.colors
-    private val elevation: Map<String, String>? = builder.elevations
+    private val colors: ImmutableMap<String, String>? = builder.colors?.toImmutableMap()
+    private val elevation: ImmutableMap<String, String>? = builder.elevations?.toImmutableMap()
     private val contentPadding: PaddingValues? = builder.contentPadding
 
     @Composable

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/CardDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/CardDTO.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.toImmutableMap
 import org.phoenixframework.liveview.data.core.CoreAttribute
-import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.data.mappers.JsonParser
 import org.phoenixframework.liveview.domain.base.ComposableBuilder
 import org.phoenixframework.liveview.domain.base.ComposableView
@@ -146,8 +145,7 @@ object CardDtoFactory : ComposableViewFactory<CardDTO, CardDTO.Builder>() {
      * @return a `CardDTO` object based on the attributes of the input `Attributes` object
      **/
     override fun buildComposableView(
-        attributes: List<CoreAttribute>,
-        children: List<CoreNodeElement>?,
+        attributes: Array<CoreAttribute>,
         pushEvent: PushEvent?,
     ): CardDTO = attributes.fold(CardDTO.Builder()) { builder, attribute ->
         when (attribute.name) {

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/CardDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/CardDTO.kt
@@ -11,6 +11,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.toImmutableMap
 import org.phoenixframework.liveview.data.core.CoreAttribute
 import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.data.mappers.JsonParser
@@ -27,8 +29,8 @@ import org.phoenixframework.liveview.ui.theme.shapeFromString
 
 class CardDTO private constructor(builder: Builder) : ComposableView(modifier = builder.modifier) {
     private val shape: Shape = builder.shape
-    private val colors: Map<String, String>? = builder.cardColors
-    private val elevation: Map<String, String>? = builder.elevation
+    private val colors: ImmutableMap<String, String>? = builder.cardColors?.toImmutableMap()
+    private val elevation: ImmutableMap<String, String>? = builder.elevation?.toImmutableMap()
 
     @Composable
     override fun Compose(
@@ -49,7 +51,7 @@ class CardDTO private constructor(builder: Builder) : ComposableView(modifier = 
     }
 
     @Composable
-    private fun getCardColors(cardColors: Map<String, String>?): CardColors {
+    private fun getCardColors(cardColors: ImmutableMap<String, String>?): CardColors {
         val defaultValue = CardDefaults.cardColors()
         return if (cardColors == null) {
             defaultValue
@@ -68,7 +70,7 @@ class CardDTO private constructor(builder: Builder) : ComposableView(modifier = 
     }
 
     @Composable
-    private fun getCardElevation(elevation: Map<String, String>?): CardElevation {
+    private fun getCardElevation(elevation: ImmutableMap<String, String>?): CardElevation {
         val defaultValue = CardDefaults.cardElevation()
         return if (elevation == null) {
             defaultValue

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/ColumnDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/ColumnDTO.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import org.phoenixframework.liveview.data.core.CoreAttribute
-import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.domain.base.ComposableBuilder
 import org.phoenixframework.liveview.domain.base.ComposableView
 import org.phoenixframework.liveview.domain.base.ComposableViewFactory
@@ -88,7 +87,8 @@ object ColumnDtoFactory : ComposableViewFactory<ColumnDTO, ColumnDTO.Builder>() 
      * @return a `ColumnDTO` object based on the attributes of the input `Attributes` object
      */
     override fun buildComposableView(
-        attributes: List<CoreAttribute>, children: List<CoreNodeElement>?, pushEvent: PushEvent?
+        attributes: Array<CoreAttribute>,
+        pushEvent: PushEvent?
     ): ColumnDTO = attributes.fold(ColumnDTO.Builder()) { builder, attribute ->
         when (attribute.name) {
             "verticalArrangement" -> builder.verticalArrangement(attribute.value)

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/IconButtonDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/IconButtonDTO.kt
@@ -6,6 +6,8 @@ import androidx.compose.material3.IconButtonColors
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.toImmutableMap
 import org.phoenixframework.liveview.data.core.CoreAttribute
 import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.data.mappers.JsonParser
@@ -22,7 +24,7 @@ class IconButtonDTO private constructor(builder: Builder) :
     ComposableView(modifier = builder.modifier) {
     private val onClick: () -> Unit = builder.onClick
     private val enabled: Boolean = builder.enabled
-    private val colors: Map<String, String>? = builder.colors
+    private val colors: ImmutableMap<String, String>? = builder.colors?.toImmutableMap()
 
     @Composable
     override fun Compose(
@@ -42,7 +44,7 @@ class IconButtonDTO private constructor(builder: Builder) :
     }
 
     @Composable
-    private fun getIconButtonColors(colors: Map<String, String>?): IconButtonColors {
+    private fun getIconButtonColors(colors: ImmutableMap<String, String>?): IconButtonColors {
         val defaultValue = IconButtonDefaults.iconButtonColors()
         return if (colors == null) {
             defaultValue

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/IconButtonDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/IconButtonDTO.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.graphics.Color
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.toImmutableMap
 import org.phoenixframework.liveview.data.core.CoreAttribute
-import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.data.mappers.JsonParser
 import org.phoenixframework.liveview.domain.base.ComposableBuilder
 import org.phoenixframework.liveview.domain.base.ComposableView
@@ -94,8 +93,7 @@ class IconButtonDTO private constructor(builder: Builder) :
 
 object IconButtonDtoFactory : ComposableViewFactory<IconButtonDTO, IconButtonDTO.Builder>() {
     override fun buildComposableView(
-        attributes: List<CoreAttribute>,
-        children: List<CoreNodeElement>?,
+        attributes: Array<CoreAttribute>,
         pushEvent: PushEvent?,
     ): IconButtonDTO = attributes.fold(
         IconButtonDTO.Builder()

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/IconDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/IconDTO.kt
@@ -9,7 +9,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import org.phoenixframework.liveview.data.core.CoreAttribute
-import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.domain.base.ComposableBuilder
 import org.phoenixframework.liveview.domain.base.ComposableView
 import org.phoenixframework.liveview.domain.base.ComposableViewFactory
@@ -62,8 +61,7 @@ class IconDTO private constructor(builder: Builder) : ComposableView(modifier = 
 
 object IconDtoFactory : ComposableViewFactory<IconDTO, IconDTO.Builder>() {
     override fun buildComposableView(
-        attributes: List<CoreAttribute>,
-        children: List<CoreNodeElement>?,
+        attributes: Array<CoreAttribute>,
         pushEvent: PushEvent?,
     ): IconDTO = attributes.fold(
         IconDTO.Builder().imageVector(attributes.find { it.name == "imageVector" }?.value ?: "")

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/LazyColumnDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/LazyColumnDTO.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.toImmutableMap
 import org.phoenixframework.liveview.data.core.CoreAttribute
 import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.domain.base.ComposableBuilder
@@ -23,10 +25,7 @@ class LazyColumnDTO private constructor(builder: Builder) :
     private val verticalArrangement: Arrangement.Vertical = builder.verticalArrangement
     private val horizontalAlignment: Alignment.Horizontal = builder.horizontalAlignment
 
-    // content padding is a pair of pairs,
-    // the first pair is the horizontal padding,
-    // the second pair is the vertical padding
-    private val contentPadding: Pair<Pair<Int, Int>, Pair<Int, Int>> = builder.contentPadding
+    private val contentPadding: ImmutableMap<String, Int> = builder.contentPadding.toImmutableMap()
 
     private val reverseLayout: Boolean = builder.reverseLayout
 
@@ -42,10 +41,10 @@ class LazyColumnDTO private constructor(builder: Builder) :
             verticalArrangement = verticalArrangement,
             horizontalAlignment = horizontalAlignment,
             contentPadding = PaddingValues(
-                contentPadding.first.first.dp,
-                contentPadding.second.first.dp,
-                contentPadding.first.second.dp,
-                contentPadding.second.second.dp
+                (contentPadding["left"] ?: 0).dp,
+                (contentPadding["top"] ?: 0).dp,
+                (contentPadding["right"] ?: 0).dp,
+                (contentPadding["bottom"] ?: 0).dp
             ),
             content = {
                 items(
@@ -61,7 +60,7 @@ class LazyColumnDTO private constructor(builder: Builder) :
     class Builder : ComposableBuilder() {
         var verticalArrangement: Arrangement.Vertical = Arrangement.Top
         var horizontalAlignment: Alignment.Horizontal = Alignment.Start
-        var contentPadding: Pair<Pair<Int, Int>, Pair<Int, Int>> = Pair(Pair(0, 0), Pair(0, 0))
+        var contentPadding: MutableMap<String, Int> = mutableMapOf()
         var reverseLayout: Boolean = false
 
         fun reverseLayout(isReverseLayout: String) = apply {
@@ -93,47 +92,33 @@ class LazyColumnDTO private constructor(builder: Builder) :
 
         fun rightPadding(paddingValue: String) = apply {
             if (paddingValue.isNotEmptyAndIsDigitsOnly()) {
-                contentPadding = Pair(
-                    Pair(contentPadding.first.first, paddingValue.toInt()),
-                    Pair(contentPadding.second.first, contentPadding.second.second)
-                )
+                contentPadding["right"] = paddingValue.toInt()
             }
         }
 
         fun leftPadding(paddingValue: String) = apply {
             if (paddingValue.isNotEmptyAndIsDigitsOnly()) {
-                contentPadding = Pair(
-                    Pair(paddingValue.toInt(), contentPadding.first.second),
-                    Pair(contentPadding.second.first, contentPadding.second.second)
-                )
+                contentPadding["left"] = paddingValue.toInt()
             }
         }
 
         fun topPadding(paddingValue: String) = apply {
             if (paddingValue.isNotEmptyAndIsDigitsOnly()) {
-                contentPadding = Pair(
-                    Pair(contentPadding.first.first, contentPadding.first.second),
-                    Pair(paddingValue.toInt(), contentPadding.second.second)
-                )
+                contentPadding["top"] = paddingValue.toInt()
             }
         }
 
         fun bottomPadding(paddingValue: String) = apply {
             if (paddingValue.isNotEmptyAndIsDigitsOnly()) {
-                contentPadding = Pair(
-                    Pair(contentPadding.first.first, contentPadding.first.second),
-                    Pair(contentPadding.second.first, paddingValue.toInt())
-                )
+                contentPadding["bottom"] = paddingValue.toInt()
             }
         }
 
         fun lazyColumnItemPadding(paddingValue: String) = apply {
-            if (paddingValue.isNotEmptyAndIsDigitsOnly()) {
-                contentPadding = Pair(
-                    Pair(paddingValue.toInt(), paddingValue.toInt()),
-                    Pair(paddingValue.toInt(), paddingValue.toInt())
-                )
-            }
+            topPadding(paddingValue)
+            leftPadding(paddingValue)
+            bottomPadding(paddingValue)
+            rightPadding(paddingValue)
         }
 
         fun build() = LazyColumnDTO(this)

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/LazyColumnDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/LazyColumnDTO.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.toImmutableMap
 import org.phoenixframework.liveview.data.core.CoreAttribute
-import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.domain.base.ComposableBuilder
 import org.phoenixframework.liveview.domain.base.ComposableView
 import org.phoenixframework.liveview.domain.base.ComposableViewFactory
@@ -48,7 +47,7 @@ class LazyColumnDTO private constructor(builder: Builder) :
             ),
             content = {
                 items(
-                    composableNode?.children ?: emptyList(),
+                    composableNode?.children ?: emptyArray(),
                     key = { item -> item.id },
                 ) { item ->
                     PhxLiveView(item, null, pushEvent)
@@ -127,8 +126,7 @@ class LazyColumnDTO private constructor(builder: Builder) :
 
 object LazyColumnDtoFactory : ComposableViewFactory<LazyColumnDTO, LazyColumnDTO.Builder>() {
     override fun buildComposableView(
-        attributes: List<CoreAttribute>,
-        children: List<CoreNodeElement>?,
+        attributes: Array<CoreAttribute>,
         pushEvent: PushEvent?,
     ): LazyColumnDTO = attributes.fold(LazyColumnDTO.Builder()) { builder, attribute ->
         when (attribute.name) {

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/LazyRowDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/LazyRowDTO.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.toImmutableMap
 import org.phoenixframework.liveview.data.core.CoreAttribute
 import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.domain.base.ComposableBuilder
@@ -23,10 +25,7 @@ class LazyRowDTO private constructor(builder: Builder) :
     private val horizontalArrangement: Arrangement.Horizontal = builder.horizontalArrangement
     private val verticalAlignment: Alignment.Vertical = builder.verticalAlignment
 
-    // content padding is a pair of pairs,
-    // the first pair is the horizontal padding,
-    // the second pair is the vertical padding
-    private val contentPadding: Pair<Pair<Int, Int>, Pair<Int, Int>> = builder.contentPadding
+    private val contentPadding: ImmutableMap<String, Int> = builder.contentPadding.toImmutableMap()
 
     private val reverseLayout: Boolean = builder.reverseLayout
 
@@ -42,10 +41,10 @@ class LazyRowDTO private constructor(builder: Builder) :
             horizontalArrangement = horizontalArrangement,
             verticalAlignment = verticalAlignment,
             contentPadding = PaddingValues(
-                contentPadding.first.first.dp,
-                contentPadding.second.first.dp,
-                contentPadding.first.second.dp,
-                contentPadding.second.second.dp
+                (contentPadding["left"] ?: 0).dp,
+                (contentPadding["top"] ?: 0).dp,
+                (contentPadding["right"] ?: 0).dp,
+                (contentPadding["bottom"] ?: 0).dp
             ),
             content = {
                 items(
@@ -61,7 +60,7 @@ class LazyRowDTO private constructor(builder: Builder) :
     class Builder : ComposableBuilder() {
         var horizontalArrangement: Arrangement.Horizontal = Arrangement.SpaceAround
         var verticalAlignment: Alignment.Vertical = Alignment.CenterVertically
-        var contentPadding: Pair<Pair<Int, Int>, Pair<Int, Int>> = Pair(Pair(0, 0), Pair(0, 0))
+        var contentPadding: MutableMap<String, Int> = mutableMapOf()
         var reverseLayout: Boolean = false
 
         fun reverseLayout(isReverseLayout: String) = apply {
@@ -99,47 +98,33 @@ class LazyRowDTO private constructor(builder: Builder) :
 
         fun rightPadding(paddingValue: String) = apply {
             if (paddingValue.isNotEmptyAndIsDigitsOnly()) {
-                contentPadding = Pair(
-                    Pair(contentPadding.first.first, paddingValue.toInt()),
-                    Pair(contentPadding.second.first, contentPadding.second.second)
-                )
+                contentPadding["right"] = paddingValue.toInt()
             }
         }
 
         fun leftPadding(paddingValue: String) = apply {
             if (paddingValue.isNotEmptyAndIsDigitsOnly()) {
-                contentPadding = Pair(
-                    Pair(paddingValue.toInt(), contentPadding.first.second),
-                    Pair(contentPadding.second.first, contentPadding.second.second)
-                )
+                contentPadding["left"] = paddingValue.toInt()
             }
         }
 
         fun topPadding(paddingValue: String) = apply {
             if (paddingValue.isNotEmptyAndIsDigitsOnly()) {
-                contentPadding = Pair(
-                    Pair(contentPadding.first.first, contentPadding.first.second),
-                    Pair(paddingValue.toInt(), contentPadding.second.second)
-                )
+                contentPadding["top"] = paddingValue.toInt()
             }
         }
 
         fun bottomPadding(paddingValue: String) = apply {
             if (paddingValue.isNotEmptyAndIsDigitsOnly()) {
-                contentPadding = Pair(
-                    Pair(contentPadding.first.first, contentPadding.first.second),
-                    Pair(contentPadding.second.first, paddingValue.toInt())
-                )
+                contentPadding["bottom"] = paddingValue.toInt()
             }
         }
 
         fun lazyRowItemPadding(paddingValue: String) = apply {
-            if (paddingValue.isNotEmptyAndIsDigitsOnly()) {
-                contentPadding = Pair(
-                    Pair(paddingValue.toInt(), paddingValue.toInt()),
-                    Pair(paddingValue.toInt(), paddingValue.toInt())
-                )
-            }
+            topPadding(paddingValue)
+            leftPadding(paddingValue)
+            bottomPadding(paddingValue)
+            rightPadding(paddingValue)
         }
 
         fun build() = LazyRowDTO(this)

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/LazyRowDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/LazyRowDTO.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.toImmutableMap
 import org.phoenixframework.liveview.data.core.CoreAttribute
-import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.domain.base.ComposableBuilder
 import org.phoenixframework.liveview.domain.base.ComposableView
 import org.phoenixframework.liveview.domain.base.ComposableViewFactory
@@ -48,7 +47,7 @@ class LazyRowDTO private constructor(builder: Builder) :
             ),
             content = {
                 items(
-                    composableNode?.children ?: emptyList(),
+                    composableNode?.children ?: emptyArray(),
                     key = { item -> item.id },
                 ) { item ->
                     PhxLiveView(item, null, pushEvent)
@@ -133,8 +132,7 @@ class LazyRowDTO private constructor(builder: Builder) :
 
 object LazyRowDtoFactory : ComposableViewFactory<LazyRowDTO, LazyRowDTO.Builder>() {
     override fun buildComposableView(
-        attributes: List<CoreAttribute>,
-        children: List<CoreNodeElement>?,
+        attributes: Array<CoreAttribute>,
         pushEvent: PushEvent?,
     ): LazyRowDTO =
         attributes.fold(LazyRowDTO.Builder()) { builder, attribute ->

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/RowDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/RowDTO.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import org.phoenixframework.liveview.data.core.CoreAttribute
-import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.domain.base.ComposableBuilder
 import org.phoenixframework.liveview.domain.base.ComposableView
 import org.phoenixframework.liveview.domain.base.ComposableViewFactory
@@ -89,8 +88,7 @@ object RowDtoFactory : ComposableViewFactory<RowDTO, RowDTO.Builder>() {
      * @return a `RowDTO` object based on the attributes of the input `Attributes` object
      */
     override fun buildComposableView(
-        attributes: List<CoreAttribute>,
-        children: List<CoreNodeElement>?,
+        attributes: Array<CoreAttribute>,
         pushEvent: PushEvent?
     ): RowDTO =
         attributes.fold(RowDTO.Builder()) { builder, attribute ->

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/ScaffoldDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/ScaffoldDTO.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import org.phoenixframework.liveview.data.core.CoreAttribute
-import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.domain.base.ComposableBuilder
 import org.phoenixframework.liveview.domain.base.ComposableTypes
 import org.phoenixframework.liveview.domain.base.ComposableView
@@ -75,8 +74,7 @@ class ScaffoldDTO private constructor(builder: Builder) :
 
 object ScaffoldDtoFactory : ComposableViewFactory<ScaffoldDTO, ScaffoldDTO.Builder>() {
     override fun buildComposableView(
-        attributes: List<CoreAttribute>,
-        children: List<CoreNodeElement>?,
+        attributes: Array<CoreAttribute>,
         pushEvent: PushEvent?,
     ): ScaffoldDTO = attributes.fold(ScaffoldDTO.Builder()) { builder, attribute ->
         when (attribute.name) {

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/SpacerDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/SpacerDTO.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.runtime.Composable
 import org.phoenixframework.liveview.data.core.CoreAttribute
-import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.domain.base.ComposableBuilder
 import org.phoenixframework.liveview.domain.base.ComposableView
 import org.phoenixframework.liveview.domain.base.ComposableViewFactory
@@ -30,8 +29,7 @@ class SpacerDTO private constructor(builder: Builder) :
 
 object SpacerDtoFactory : ComposableViewFactory<SpacerDTO, SpacerDTO.Builder>() {
     override fun buildComposableView(
-        attributes: List<CoreAttribute>,
-        children: List<CoreNodeElement>?,
+        attributes: Array<CoreAttribute>,
         pushEvent: PushEvent?
     ): SpacerDTO = attributes.fold(SpacerDTO.Builder()) { builder, attribute ->
         when (attribute.name) {

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/TextDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/TextDTO.kt
@@ -271,7 +271,7 @@ class TextDTO private constructor(builder: Builder) :
 object TextDtoFactory : ComposableViewFactory<TextDTO, TextDTO.Builder>() {
     fun buildComposableView(
         text: String,
-        attributes: List<CoreAttribute>,
+        attributes: Array<CoreAttribute>,
     ): TextDTO = textBuilder(attributes).text(text).build()
 
     /**
@@ -283,12 +283,11 @@ object TextDtoFactory : ComposableViewFactory<TextDTO, TextDTO.Builder>() {
      * @return a `TextDTO` object based on the attributes and text of the input `Attributes` object
      */
     override fun buildComposableView(
-        attributes: List<CoreAttribute>,
-        children: List<CoreNodeElement>?,
+        attributes: Array<CoreAttribute>,
         pushEvent: PushEvent?
     ): TextDTO = textBuilder(attributes).build()
 
-    private fun textBuilder(attributes: List<CoreAttribute>): TextDTO.Builder =
+    private fun textBuilder(attributes: Array<CoreAttribute>): TextDTO.Builder =
         attributes.fold(TextDTO.Builder()) { builder, attribute ->
             when (attribute.name) {
                 "text" -> builder.text(attribute.value)

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/TextDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/TextDTO.kt
@@ -3,6 +3,7 @@ package org.phoenixframework.liveview.data.dto
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
@@ -28,7 +29,7 @@ import org.phoenixframework.liveview.ui.theme.textAlignFromString
 import org.phoenixframework.liveview.ui.theme.textDecorationFromString
 import org.phoenixframework.liveview.ui.theme.textStyleFromString
 
-class TextDTO private constructor(private val builder: Builder) :
+class TextDTO private constructor(builder: Builder) :
     ComposableView(modifier = builder.modifier) {
 
     private val color: Color = builder.color
@@ -51,8 +52,11 @@ class TextDTO private constructor(private val builder: Builder) :
         paddingValues: PaddingValues?,
         pushEvent: PushEvent,
     ) {
+        val text = remember(composableNode) {
+            getText(composableNode)
+        }
         Text(
-            text = composableNode?.text ?: "",
+            text = text,
             color = color,
             modifier = modifier,
             fontSize = fontSize,
@@ -68,6 +72,23 @@ class TextDTO private constructor(private val builder: Builder) :
             textDecoration = textDecoration,
             style = textStyleFromString(style),
         )
+    }
+
+    private fun getText(composableNode: ComposableTreeNode?): String {
+        // The first (and only) children node of a Text element must be the text itself.
+        // It is contained in a attribute called "text"
+        val childrenNodes = composableNode?.children
+        var text = ""
+        if (childrenNodes?.isNotEmpty() == true) {
+            val firstNode = childrenNodes.first().node
+            if (firstNode?.attributes?.isNotEmpty() == true) {
+                val firstAttr = firstNode.attributes.first()
+                if (firstAttr.name == CoreNodeElement.TEXT_ATTRIBUTE) {
+                    text = firstAttr.value
+                }
+            }
+        }
+        return text
     }
 
     class Builder : ComposableBuilder() {

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/TopAppBarDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/TopAppBarDTO.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.graphics.Color
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.toImmutableMap
 import org.phoenixframework.liveview.data.core.CoreAttribute
-import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.data.dto.TopAppBarDtoFactory.actionTag
 import org.phoenixframework.liveview.data.dto.TopAppBarDtoFactory.navigationIconTag
 import org.phoenixframework.liveview.data.dto.TopAppBarDtoFactory.titleTag
@@ -122,8 +121,7 @@ class TopAppBarDTO private constructor(builder: Builder) :
 
 object TopAppBarDtoFactory : ComposableViewFactory<TopAppBarDTO, TopAppBarDTO.Builder>() {
     override fun buildComposableView(
-        attributes: List<CoreAttribute>,
-        children: List<CoreNodeElement>?,
+        attributes: Array<CoreAttribute>,
         pushEvent: PushEvent?
     ): TopAppBarDTO {
         val builder = TopAppBarDTO.Builder()

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/TopAppBarDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/TopAppBarDTO.kt
@@ -10,7 +10,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
-import kotlinx.collections.immutable.toImmutableList
 import org.phoenixframework.liveview.data.core.CoreAttribute
 import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.data.dto.TopAppBarDtoFactory.actionTag
@@ -42,13 +41,13 @@ class TopAppBarDTO private constructor(builder: Builder) :
             composableNode?.children?.find { it.node?.tag == titleTag }
         }
         val actions = remember(composableNode?.children) {
-            composableNode?.children?.filter { it.node?.tag == actionTag }?.toImmutableList()
+            composableNode?.children?.filter { it.node?.tag == actionTag }
         }
         val navIcon = remember(composableNode?.children) {
             composableNode?.children?.find { it.node?.tag == navigationIconTag }
         }
         TopAppBar(
-            colors = getTopAppBarColors(colors = colors) ?: TopAppBarDefaults.topAppBarColors(),
+            colors = getTopAppBarColors(colors = colors),
             title = {
                 title?.let {
                     PhxLiveView(it, null, pushEvent)
@@ -88,7 +87,7 @@ class TopAppBarDTO private constructor(builder: Builder) :
 
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
-    private fun getTopAppBarColors(colors: Map<String, String>?): TopAppBarColors? {
+    private fun getTopAppBarColors(colors: Map<String, String>?): TopAppBarColors {
         val defaultColors = TopAppBarDefaults.topAppBarColors()
         return if (colors == null) {
             defaultColors

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/TopAppBarDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/TopAppBarDTO.kt
@@ -10,6 +10,8 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.toImmutableMap
 import org.phoenixframework.liveview.data.core.CoreAttribute
 import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.data.dto.TopAppBarDtoFactory.actionTag
@@ -28,7 +30,7 @@ import org.phoenixframework.liveview.ui.phx_components.PhxLiveView
 class TopAppBarDTO private constructor(builder: Builder) :
     ComposableView(modifier = builder.modifier) {
 
-    private val colors: Map<String, String>? = builder.colors
+    private val colors: ImmutableMap<String, String>? = builder.colors?.toImmutableMap()
 
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
@@ -87,7 +89,7 @@ class TopAppBarDTO private constructor(builder: Builder) :
 
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
-    private fun getTopAppBarColors(colors: Map<String, String>?): TopAppBarColors {
+    private fun getTopAppBarColors(colors: ImmutableMap<String, String>?): TopAppBarColors {
         val defaultColors = TopAppBarDefaults.topAppBarColors()
         return if (colors == null) {
             defaultColors

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/ThemeHolder.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/ThemeHolder.kt
@@ -1,10 +1,13 @@
 package org.phoenixframework.liveview.domain
 
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 object ThemeHolder {
-    private val _themeData = MutableStateFlow<Map<String, Any>>(emptyMap())
+    private val _themeData = MutableStateFlow<ImmutableMap<String, Any>>(persistentMapOf())
     val themeData = _themeData.asStateFlow()
 
     val isEmpty: Boolean
@@ -12,7 +15,7 @@ object ThemeHolder {
 
     fun updateThemeData(themeData: Map<String, Any>?) {
         if (themeData != null) {
-            _themeData.value = themeData
+            _themeData.value = themeData.toImmutableMap()
         }
     }
 }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/base/ComposableView.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/base/ComposableView.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import org.phoenixframework.liveview.data.core.CoreAttribute
-import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.domain.extensions.isNotEmptyAndIsDigitsOnly
 import org.phoenixframework.liveview.domain.factory.ComposableTreeNode
 
@@ -128,8 +127,7 @@ abstract class ComposableBuilder {
 
 abstract class ComposableViewFactory<CV : ComposableView, CB : ComposableBuilder> {
     abstract fun buildComposableView(
-        attributes: List<CoreAttribute>,
-        children: List<CoreNodeElement>?,
+        attributes: Array<CoreAttribute>,
         pushEvent: PushEvent?
     ): CV
 }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/base/ComposableView.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/base/ComposableView.kt
@@ -22,7 +22,7 @@ import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.domain.extensions.isNotEmptyAndIsDigitsOnly
 import org.phoenixframework.liveview.domain.factory.ComposableTreeNode
 
-abstract class ComposableView(var modifier: Modifier = Modifier) {
+abstract class ComposableView(val modifier: Modifier = Modifier) {
 
     @Composable
     abstract fun Compose(

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
@@ -1,7 +1,5 @@
 package org.phoenixframework.liveview.domain.factory
 
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.toImmutableList
 import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.data.dto.AsyncImageDtoFactory
 import org.phoenixframework.liveview.data.dto.ButtonDtoFactory
@@ -64,16 +62,17 @@ object ComposableNodeFactory {
         children: List<CoreNodeElement>,
     ): ComposableTreeNode {
         return ComposableTreeNode(
-            screenId,
-            nodeRef.ref,
-            element,
-            children.toImmutableList(),
+            screenId = screenId,
+            refId = nodeRef.ref,
+            node = element,
+            id = "${screenId}_${nodeRef.ref}",
+            coreChildrenNodes = children
         )
     }
 
     fun buildComposableView(
         element: CoreNodeElement?,
-        children: ImmutableList<CoreNodeElement>?,
+        children: List<CoreNodeElement>?,
         pushEvent: PushEvent,
     ): ComposableView {
         return if (element != null) {

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
@@ -1,5 +1,6 @@
 package org.phoenixframework.liveview.domain.factory
 
+import kotlinx.collections.immutable.ImmutableList
 import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.data.dto.AsyncImageDtoFactory
 import org.phoenixframework.liveview.data.dto.ButtonDtoFactory
@@ -59,27 +60,25 @@ object ComposableNodeFactory {
         screenId: String,
         nodeRef: NodeRef,
         element: CoreNodeElement,
-        children: List<CoreNodeElement>,
     ): ComposableTreeNode {
         return ComposableTreeNode(
             screenId = screenId,
             refId = nodeRef.ref,
             node = element,
             id = "${screenId}_${nodeRef.ref}",
-            coreChildrenNodes = children
         )
     }
 
     fun buildComposableView(
         element: CoreNodeElement?,
-        children: List<CoreNodeElement>?,
+        children: ImmutableList<ComposableTreeNode>,
         pushEvent: PushEvent,
     ): ComposableView {
         return if (element != null) {
             val tag = element.tag
             val attrs = element.attributes
             ComposableRegistry.getComponentFactory(tag)?.buildComposableView(
-                attrs, children, pushEvent
+                attrs, children.mapNotNull { it.node }, pushEvent
             ) ?: run {
                 TextDtoFactory.buildComposableView(
                     "$tag not supported yet",

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableNodeFactory.kt
@@ -1,6 +1,5 @@
 package org.phoenixframework.liveview.domain.factory
 
-import kotlinx.collections.immutable.ImmutableList
 import org.phoenixframework.liveview.data.core.CoreNodeElement
 import org.phoenixframework.liveview.data.dto.AsyncImageDtoFactory
 import org.phoenixframework.liveview.data.dto.ButtonDtoFactory
@@ -71,14 +70,13 @@ object ComposableNodeFactory {
 
     fun buildComposableView(
         element: CoreNodeElement?,
-        children: ImmutableList<ComposableTreeNode>,
         pushEvent: PushEvent,
     ): ComposableView {
         return if (element != null) {
             val tag = element.tag
             val attrs = element.attributes
             ComposableRegistry.getComponentFactory(tag)?.buildComposableView(
-                attrs, children.mapNotNull { it.node }, pushEvent
+                attrs, pushEvent
             ) ?: run {
                 TextDtoFactory.buildComposableView(
                     "$tag not supported yet",
@@ -88,7 +86,7 @@ object ComposableNodeFactory {
         } else {
             TextDtoFactory.buildComposableView(
                 "Invalid element",
-                emptyList(),
+                emptyArray(),
             )
         }
     }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableTree.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableTree.kt
@@ -1,22 +1,41 @@
 package org.phoenixframework.liveview.domain.factory
 
+import androidx.compose.runtime.Stable
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import org.phoenixframework.liveview.data.core.CoreNodeElement
 import java.util.UUID
 
+@Stable
 data class ComposableTreeNode(
     val screenId: String,
     val refId: Int,
     val node: CoreNodeElement?,
-    var text: String = "",
     val id: String = UUID.randomUUID().toString(),
-    val coreChildrenNodes: List<CoreNodeElement> = emptyList(),
 ) {
-    val children: List<ComposableTreeNode>
-        get() = _children
+    val children: ImmutableList<ComposableTreeNode>
+        get() = _children.toImmutableList()
 
     private val _children: MutableList<ComposableTreeNode> = mutableListOf()
 
     fun addNode(child: ComposableTreeNode) {
         _children.add(child)
+    }
+
+    // Adding
+    override fun equals(other: Any?): Boolean {
+        return super.equals(other) && (other as ComposableTreeNode).children.toTypedArray()
+            .contentDeepEquals(
+                children.toTypedArray()
+            )
+    }
+
+    override fun hashCode(): Int {
+        var result = screenId.hashCode()
+        result = 31 * result + refId
+        result = 31 * result + (node?.hashCode() ?: 0)
+        result = 31 * result + id.hashCode()
+        result = 31 * result + children.hashCode()
+        return result
     }
 }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableTree.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableTree.kt
@@ -1,20 +1,18 @@
 package org.phoenixframework.liveview.domain.factory
 
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.toImmutableList
 import org.phoenixframework.liveview.data.core.CoreNodeElement
 import java.util.UUID
 
 data class ComposableTreeNode(
     val screenId: String,
-    var refId: Int,
+    val refId: Int,
     val node: CoreNodeElement?,
-    val childrenNodes: ImmutableList<CoreNodeElement>?,
     var text: String = "",
-    val id: String = UUID.randomUUID().toString()
+    val id: String = UUID.randomUUID().toString(),
+    val coreChildrenNodes: List<CoreNodeElement> = emptyList(),
 ) {
-    val children: ImmutableList<ComposableTreeNode>
-        get() = _children.toImmutableList()
+    val children: List<ComposableTreeNode>
+        get() = _children
 
     private val _children: MutableList<ComposableTreeNode> = mutableListOf()
 

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableTree.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/factory/ComposableTree.kt
@@ -1,8 +1,6 @@
 package org.phoenixframework.liveview.domain.factory
 
 import androidx.compose.runtime.Stable
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.toImmutableList
 import org.phoenixframework.liveview.data.core.CoreNodeElement
 import java.util.UUID
 
@@ -13,23 +11,15 @@ data class ComposableTreeNode(
     val node: CoreNodeElement?,
     val id: String = UUID.randomUUID().toString(),
 ) {
-    val children: ImmutableList<ComposableTreeNode>
-        get() = _children.toImmutableList()
-
-    private val _children: MutableList<ComposableTreeNode> = mutableListOf()
+    var children: Array<ComposableTreeNode> = emptyArray()
+        private set
 
     fun addNode(child: ComposableTreeNode) {
-        _children.add(child)
+        children = arrayOf(*children, child)
     }
 
-    // Adding
-    override fun equals(other: Any?): Boolean {
-        return super.equals(other) && (other as ComposableTreeNode).children.toTypedArray()
-            .contentDeepEquals(
-                children.toTypedArray()
-            )
-    }
-
+    // The hashCode and equals functions has an important role in terms of performance.
+    // They guarantee that a composable function will be called again (recomposed) or not.
     override fun hashCode(): Int {
         var result = screenId.hashCode()
         result = 31 * result + refId
@@ -37,5 +27,18 @@ data class ComposableTreeNode(
         result = 31 * result + id.hashCode()
         result = 31 * result + children.hashCode()
         return result
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ComposableTreeNode
+
+        if (screenId != other.screenId) return false
+        if (refId != other.refId) return false
+        if (node != other.node) return false
+        if (id != other.id) return false
+        return children.contentDeepEquals(other.children)
     }
 }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/LiveView.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/LiveView.kt
@@ -94,10 +94,10 @@ private fun NavDestination(
             )
         }
     )
-    val state by liveViewCoordinator.backStack.collectAsState()
-    if (state.isNotEmpty()) {
+    val state by liveViewCoordinator.composableTree.collectAsState()
+    if (state.children.isNotEmpty()) {
         PhxLiveView(
-            composableNode = state.peek().children.first(),
+            composableNode = state.children.first(),
             pushEvent = liveViewCoordinator::pushEvent
         )
     }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/PhxLiveView.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/PhxLiveView.kt
@@ -17,7 +17,7 @@ fun PhxLiveView(
 ) {
     val composableView = remember(composableNode) {
         ComposableNodeFactory.buildComposableView(
-            composableNode.node, composableNode.coreChildrenNodes, pushEvent
+            composableNode.node, composableNode.children, pushEvent
         )
     }
     composableView.Compose(

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/PhxLiveView.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/PhxLiveView.kt
@@ -17,7 +17,7 @@ fun PhxLiveView(
 ) {
     val composableView = remember(composableNode) {
         ComposableNodeFactory.buildComposableView(
-            composableNode.node, composableNode.children, pushEvent
+            composableNode.node, pushEvent
         )
     }
     composableView.Compose(

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/PhxLiveView.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/ui/phx_components/PhxLiveView.kt
@@ -3,11 +3,8 @@ package org.phoenixframework.liveview.ui.phx_components
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import org.phoenixframework.liveview.domain.LiveViewCoordinator
 import org.phoenixframework.liveview.domain.base.PushEvent
 import org.phoenixframework.liveview.domain.factory.ComposableNodeFactory
 import org.phoenixframework.liveview.domain.factory.ComposableTreeNode
@@ -18,14 +15,13 @@ fun PhxLiveView(
     paddingValues: PaddingValues? = null,
     pushEvent: PushEvent
 ) {
-    val state by LiveViewCoordinator.getNodeState(composableNode).collectAsState()
-    val composableView = remember(state) {
+    val composableView = remember(composableNode) {
         ComposableNodeFactory.buildComposableView(
-            state?.node, state?.childrenNodes, pushEvent
+            composableNode.node, composableNode.coreChildrenNodes, pushEvent
         )
     }
     composableView.Compose(
-        composableNode = state,
+        composableNode = composableNode,
         paddingValues = paddingValues,
         pushEvent = pushEvent
     )

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/ui/theme/Theme.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/ui/theme/Theme.kt
@@ -8,13 +8,15 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.persistentMapOf
 
 @Composable
 fun LiveViewNativeTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     // Dynamic color is available on Android 12+
     dynamicColor: Boolean = false,
-    themeData: Map<String, Any> = emptyMap(),
+    themeData: ImmutableMap<String, Any> = persistentMapOf(),
     content: @Composable () -> Unit
 ) {
     val colorScheme = getColorScheme(darkTheme, dynamicColor, themeData)


### PR DESCRIPTION
This PR includes changes related to new diff/merge logic implemented by Core and Core Jetpack in accordance with [this PR](https://github.com/liveview-native/liveview-native-core-jetpack/pull/10).

This PR also includes performance improvements after running the [stability report](https://developer.android.com/jetpack/compose/performance/stability). In order to avoid unnecessary recompositions and allow skipability by defining stability for main data classes like `CoreAttribute`, `CoreNodeElement`, and `ComposableTree`. 
- Implemented custom `equals` and `hashCode` functions in order to consider the equality of list/array fields.
- Added proper `@Stable` and `@Immutable` annotations to proper classes.
- Replacing `MutableMap`s by `ImmutableMaps`s.
- Given these improvements, the single node notification change was removed.