### PR TITLE
Removing reflection usage for default values

### DIFF
--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/constants/TypedValues.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/constants/TypedValues.kt
@@ -1,0 +1,12 @@
+package org.phoenixframework.liveview.data.constants
+
+import androidx.compose.ui.unit.dp
+
+object DefaultElevationValues {
+    val Level0 = 0.0.dp
+    val Level1 = 1.0.dp
+    val Level2 = 3.0.dp
+    val Level3 = 6.0.dp
+    val Level4 = 8.0.dp
+    val Level5 = 12.0.dp
+}

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/ButtonDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/ButtonDTO.kt
@@ -29,6 +29,9 @@ import org.phoenixframework.liveview.data.constants.ColorAttrs.colorAttrContaine
 import org.phoenixframework.liveview.data.constants.ColorAttrs.colorAttrContentColor
 import org.phoenixframework.liveview.data.constants.ColorAttrs.colorAttrDisabledContainerColor
 import org.phoenixframework.liveview.data.constants.ColorAttrs.colorAttrDisabledContentColor
+import org.phoenixframework.liveview.data.constants.DefaultElevationValues.Level0
+import org.phoenixframework.liveview.data.constants.DefaultElevationValues.Level1
+import org.phoenixframework.liveview.data.constants.DefaultElevationValues.Level2
 import org.phoenixframework.liveview.data.constants.ElevationAttrs.elevationAttrDefaultElevation
 import org.phoenixframework.liveview.data.constants.ElevationAttrs.elevationAttrDisabledElevation
 import org.phoenixframework.liveview.data.constants.ElevationAttrs.elevationAttrFocusedElevation
@@ -42,7 +45,6 @@ import org.phoenixframework.liveview.domain.base.ComposableTypes
 import org.phoenixframework.liveview.domain.base.ComposableView
 import org.phoenixframework.liveview.domain.base.ComposableViewFactory
 import org.phoenixframework.liveview.domain.base.PushEvent
-import org.phoenixframework.liveview.domain.extensions.privateField
 import org.phoenixframework.liveview.domain.extensions.toColor
 import org.phoenixframework.liveview.domain.factory.ComposableTreeNode
 import org.phoenixframework.liveview.ui.phx_components.PhxLiveView
@@ -188,15 +190,15 @@ internal class ButtonDTO private constructor(builder: Builder) :
         return if (elevation == null) {
             defaultElevation
         } else {
-            fun value(key: String) =
-                elevation[key]?.toIntOrNull()?.dp ?: Dp(defaultElevation.privateField(key))
+            fun value(key: String, defaultValue: Dp) =
+                elevation[key]?.toIntOrNull()?.dp ?: defaultValue
 
             ButtonDefaults.buttonElevation(
-                defaultElevation = value(elevationAttrDefaultElevation),
-                pressedElevation = value(elevationAttrPressedElevation),
-                focusedElevation = value(elevationAttrFocusedElevation),
-                hoveredElevation = value(elevationAttrHoveredElevation),
-                disabledElevation = value(elevationAttrDisabledElevation)
+                defaultElevation = value(elevationAttrDefaultElevation, Level0),
+                pressedElevation = value(elevationAttrPressedElevation, Level0),
+                focusedElevation = value(elevationAttrFocusedElevation, Level0),
+                hoveredElevation = value(elevationAttrHoveredElevation, Level1),
+                disabledElevation = value(elevationAttrDisabledElevation, Level0)
             )
         }
     }
@@ -207,15 +209,15 @@ internal class ButtonDTO private constructor(builder: Builder) :
         return if (elevation == null) {
             defaultElevation
         } else {
-            fun value(key: String) =
-                elevation[key]?.toIntOrNull()?.dp ?: Dp(defaultElevation.privateField(key))
+            fun value(key: String, defaultValue: Dp) =
+                elevation[key]?.toIntOrNull()?.dp ?: defaultValue
 
             ButtonDefaults.elevatedButtonElevation(
-                defaultElevation = value(elevationAttrDefaultElevation),
-                pressedElevation = value(elevationAttrPressedElevation),
-                focusedElevation = value(elevationAttrFocusedElevation),
-                hoveredElevation = value(elevationAttrHoveredElevation),
-                disabledElevation = value(elevationAttrDisabledElevation)
+                defaultElevation = value(elevationAttrDefaultElevation, Level1),
+                pressedElevation = value(elevationAttrPressedElevation, Level1),
+                focusedElevation = value(elevationAttrFocusedElevation, Level1),
+                hoveredElevation = value(elevationAttrHoveredElevation, Level2),
+                disabledElevation = value(elevationAttrDisabledElevation, Level0)
             )
         }
     }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/CardDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/CardDTO.kt
@@ -27,6 +27,11 @@ import org.phoenixframework.liveview.data.constants.Attrs.attrScroll
 import org.phoenixframework.liveview.data.constants.Attrs.attrShape
 import org.phoenixframework.liveview.data.constants.ColorAttrs.colorAttrContainerColor
 import org.phoenixframework.liveview.data.constants.ColorAttrs.colorAttrContentColor
+import org.phoenixframework.liveview.data.constants.DefaultElevationValues.Level0
+import org.phoenixframework.liveview.data.constants.DefaultElevationValues.Level1
+import org.phoenixframework.liveview.data.constants.DefaultElevationValues.Level2
+import org.phoenixframework.liveview.data.constants.DefaultElevationValues.Level3
+import org.phoenixframework.liveview.data.constants.DefaultElevationValues.Level4
 import org.phoenixframework.liveview.data.constants.ElevationAttrs.elevationAttrDefaultElevation
 import org.phoenixframework.liveview.data.constants.ElevationAttrs.elevationAttrDisabledElevation
 import org.phoenixframework.liveview.data.constants.ElevationAttrs.elevationAttrDraggedElevation
@@ -41,7 +46,6 @@ import org.phoenixframework.liveview.domain.base.ComposableViewFactory
 import org.phoenixframework.liveview.domain.base.PushEvent
 import org.phoenixframework.liveview.domain.extensions.optional
 import org.phoenixframework.liveview.domain.extensions.paddingIfNotNull
-import org.phoenixframework.liveview.domain.extensions.privateField
 import org.phoenixframework.liveview.domain.extensions.toColor
 import org.phoenixframework.liveview.domain.factory.ComposableTreeNode
 import org.phoenixframework.liveview.ui.phx_components.PhxLiveView
@@ -194,60 +198,61 @@ internal class CardDTO private constructor(builder: Builder) :
 
     @Composable
     private fun getCardElevation(elevation: ImmutableMap<String, String>?): CardElevation {
-        val defaultValue = CardDefaults.cardElevation()
+        val defaultElevation = CardDefaults.cardElevation()
         return if (elevation == null) {
-            defaultValue
+            defaultElevation
         } else {
-            fun value(key: String) =
-                elevation[key]?.toIntOrNull()?.dp ?: Dp(defaultValue.privateField(key))
+            fun value(key: String, defaultValue: Dp) =
+                elevation[key]?.toIntOrNull()?.dp ?: defaultValue
 
             CardDefaults.cardElevation(
-                defaultElevation = value(elevationAttrDefaultElevation),
-                pressedElevation = value(elevationAttrPressedElevation),
-                focusedElevation = value(elevationAttrFocusedElevation),
-                hoveredElevation = value(elevationAttrHoveredElevation),
-                draggedElevation = value(elevationAttrDraggedElevation),
-                disabledElevation = value(elevationAttrDisabledElevation),
+                defaultElevation = value(elevationAttrDefaultElevation, Level0),
+                pressedElevation = value(elevationAttrPressedElevation, Level0),
+                focusedElevation = value(elevationAttrFocusedElevation, Level0),
+                hoveredElevation = value(elevationAttrHoveredElevation, Level0),
+                draggedElevation = value(elevationAttrDraggedElevation, Level3),
+                disabledElevation = value(elevationAttrDisabledElevation, Level0),
             )
         }
     }
 
     @Composable
     private fun getElevatedCardElevation(elevation: ImmutableMap<String, String>?): CardElevation {
-        val defaultValue = CardDefaults.elevatedCardElevation()
+        val defaultElevation = CardDefaults.elevatedCardElevation()
         return if (elevation == null) {
-            defaultValue
+            defaultElevation
         } else {
-            fun value(key: String) =
-                elevation[key]?.toIntOrNull()?.dp ?: Dp(defaultValue.privateField(key))
+            fun value(key: String, defaultValue: Dp) =
+                elevation[key]?.toIntOrNull()?.dp ?: defaultValue
 
             CardDefaults.elevatedCardElevation(
-                defaultElevation = value(elevationAttrDefaultElevation),
-                pressedElevation = value(elevationAttrPressedElevation),
-                focusedElevation = value(elevationAttrFocusedElevation),
-                hoveredElevation = value(elevationAttrHoveredElevation),
-                draggedElevation = value(elevationAttrDraggedElevation),
-                disabledElevation = value(elevationAttrDisabledElevation),
+                defaultElevation = value(elevationAttrDefaultElevation, Level1),
+                pressedElevation = value(elevationAttrPressedElevation, Level1),
+                focusedElevation = value(elevationAttrFocusedElevation, Level1),
+                hoveredElevation = value(elevationAttrHoveredElevation, Level2),
+                draggedElevation = value(elevationAttrDraggedElevation, Level4),
+                disabledElevation = value(elevationAttrDisabledElevation, Level1),
             )
         }
     }
 
     @Composable
     private fun getOutlinedCardElevation(elevation: ImmutableMap<String, String>?): CardElevation {
-        val defaultValue = CardDefaults.outlinedCardElevation()
+        val defaultElevation = CardDefaults.outlinedCardElevation()
         return if (elevation == null) {
-            defaultValue
+            defaultElevation
         } else {
-            fun value(key: String) =
-                elevation[key]?.toIntOrNull()?.dp ?: Dp(defaultValue.privateField(key))
+            fun value(key: String, defaultValue: Dp) =
+                elevation[key]?.toIntOrNull()?.dp ?: defaultValue
 
+            val defElevation = elevation[elevationAttrDefaultElevation]?.toIntOrNull()?.dp ?: Level0
             CardDefaults.outlinedCardElevation(
-                defaultElevation = value(elevationAttrDefaultElevation),
-                pressedElevation = value(elevationAttrPressedElevation),
-                focusedElevation = value(elevationAttrFocusedElevation),
-                hoveredElevation = value(elevationAttrHoveredElevation),
-                draggedElevation = value(elevationAttrDraggedElevation),
-                disabledElevation = value(elevationAttrDisabledElevation),
+                defaultElevation = value(elevationAttrDefaultElevation, Level0),
+                pressedElevation = value(elevationAttrPressedElevation, defElevation),
+                focusedElevation = value(elevationAttrFocusedElevation, defElevation),
+                hoveredElevation = value(elevationAttrHoveredElevation, defElevation),
+                draggedElevation = value(elevationAttrDraggedElevation, Level3),
+                disabledElevation = value(elevationAttrDisabledElevation, Level0),
             )
         }
     }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/ChipDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/ChipDTO.kt
@@ -52,6 +52,10 @@ import org.phoenixframework.liveview.data.constants.ColorAttrs.colorAttrSelected
 import org.phoenixframework.liveview.data.constants.ColorAttrs.colorAttrSelectedTrailingIconColor
 import org.phoenixframework.liveview.data.constants.ColorAttrs.colorAttrTrailingIconColor
 import org.phoenixframework.liveview.data.constants.ColorAttrs.colorAttrTrailingIconContentColor
+import org.phoenixframework.liveview.data.constants.DefaultElevationValues.Level0
+import org.phoenixframework.liveview.data.constants.DefaultElevationValues.Level1
+import org.phoenixframework.liveview.data.constants.DefaultElevationValues.Level2
+import org.phoenixframework.liveview.data.constants.DefaultElevationValues.Level4
 import org.phoenixframework.liveview.data.constants.ElevationAttrs.elevationAttrDisabledElevation
 import org.phoenixframework.liveview.data.constants.ElevationAttrs.elevationAttrDraggedElevation
 import org.phoenixframework.liveview.data.constants.ElevationAttrs.elevationAttrElevation
@@ -69,7 +73,6 @@ import org.phoenixframework.liveview.domain.base.ComposableTypes
 import org.phoenixframework.liveview.domain.base.ComposableView
 import org.phoenixframework.liveview.domain.base.ComposableViewFactory
 import org.phoenixframework.liveview.domain.base.PushEvent
-import org.phoenixframework.liveview.domain.extensions.privateField
 import org.phoenixframework.liveview.domain.extensions.toColor
 import org.phoenixframework.liveview.domain.factory.ComposableTreeNode
 import org.phoenixframework.liveview.ui.phx_components.PhxLiveView
@@ -530,16 +533,17 @@ internal class ChipDTO private constructor(builder: Builder) :
         return if (elevation == null) {
             defaultElevation
         } else {
-            fun value(key: String) =
-                elevation[key]?.toIntOrNull()?.dp ?: Dp(defaultElevation.privateField(key))
+            fun value(key: String, defaultElevation: Dp) =
+                elevation[key]?.toIntOrNull()?.dp ?: defaultElevation
 
+            val defValue = elevation[elevationAttrElevation]?.toIntOrNull()?.dp ?: Level0
             AssistChipDefaults.assistChipElevation(
-                elevation = value(elevationAttrElevation),
-                pressedElevation = value(elevationAttrPressedElevation),
-                focusedElevation = value(elevationAttrFocusedElevation),
-                hoveredElevation = value(elevationAttrHoveredElevation),
-                draggedElevation = value(elevationAttrDraggedElevation),
-                disabledElevation = value(elevationAttrDisabledElevation),
+                elevation = value(elevationAttrElevation, defValue),
+                pressedElevation = value(elevationAttrPressedElevation, defValue),
+                focusedElevation = value(elevationAttrFocusedElevation, defValue),
+                hoveredElevation = value(elevationAttrHoveredElevation, defValue),
+                draggedElevation = value(elevationAttrDraggedElevation, Level4),
+                disabledElevation = value(elevationAttrDisabledElevation, defValue),
             )
         }
     }
@@ -550,16 +554,16 @@ internal class ChipDTO private constructor(builder: Builder) :
         return if (elevation == null) {
             defaultElevation
         } else {
-            fun value(key: String) =
-                elevation[key]?.toIntOrNull()?.dp ?: Dp(defaultElevation.privateField(key))
+            fun value(key: String, defaultValue: Dp) =
+                elevation[key]?.toIntOrNull()?.dp ?: defaultValue
 
             AssistChipDefaults.elevatedAssistChipElevation(
-                elevation = value(elevationAttrElevation),
-                pressedElevation = value(elevationAttrPressedElevation),
-                focusedElevation = value(elevationAttrFocusedElevation),
-                hoveredElevation = value(elevationAttrHoveredElevation),
-                draggedElevation = value(elevationAttrDraggedElevation),
-                disabledElevation = value(elevationAttrDisabledElevation),
+                elevation = value(elevationAttrElevation, Level1),
+                pressedElevation = value(elevationAttrPressedElevation, Level1),
+                focusedElevation = value(elevationAttrFocusedElevation, Level1),
+                hoveredElevation = value(elevationAttrHoveredElevation, Level2),
+                draggedElevation = value(elevationAttrDraggedElevation, Level4),
+                disabledElevation = value(elevationAttrDisabledElevation, Level0),
             )
         }
     }
@@ -570,16 +574,17 @@ internal class ChipDTO private constructor(builder: Builder) :
         return if (elevation == null) {
             defaultElevation
         } else {
-            fun value(key: String) =
-                elevation[key]?.toIntOrNull()?.dp ?: Dp(defaultElevation.privateField(key))
+            fun value(key: String, defaultValue: Dp) =
+                elevation[key]?.toIntOrNull()?.dp ?: defaultValue
 
+            val defValue = elevation[elevationAttrElevation]?.toIntOrNull()?.dp ?: Level0
             SuggestionChipDefaults.suggestionChipElevation(
-                elevation = value(elevationAttrElevation),
-                pressedElevation = value(elevationAttrPressedElevation),
-                focusedElevation = value(elevationAttrFocusedElevation),
-                hoveredElevation = value(elevationAttrHoveredElevation),
-                draggedElevation = value(elevationAttrDraggedElevation),
-                disabledElevation = value(elevationAttrDisabledElevation),
+                elevation = value(elevationAttrElevation, Level0),
+                pressedElevation = value(elevationAttrPressedElevation, defValue),
+                focusedElevation = value(elevationAttrFocusedElevation, defValue),
+                hoveredElevation = value(elevationAttrHoveredElevation, defValue),
+                draggedElevation = value(elevationAttrDraggedElevation, Level4),
+                disabledElevation = value(elevationAttrDisabledElevation, defValue),
             )
         }
     }
@@ -590,16 +595,16 @@ internal class ChipDTO private constructor(builder: Builder) :
         return if (elevation == null) {
             defaultElevation
         } else {
-            fun value(key: String) =
-                elevation[key]?.toIntOrNull()?.dp ?: Dp(defaultElevation.privateField(key))
+            fun value(key: String, defaultValue: Dp) =
+                elevation[key]?.toIntOrNull()?.dp ?: defaultValue
 
             SuggestionChipDefaults.elevatedSuggestionChipElevation(
-                elevation = value(elevationAttrElevation),
-                pressedElevation = value(elevationAttrPressedElevation),
-                focusedElevation = value(elevationAttrFocusedElevation),
-                hoveredElevation = value(elevationAttrHoveredElevation),
-                draggedElevation = value(elevationAttrDraggedElevation),
-                disabledElevation = value(elevationAttrDisabledElevation),
+                elevation = value(elevationAttrElevation, Level1),
+                pressedElevation = value(elevationAttrPressedElevation, Level1),
+                focusedElevation = value(elevationAttrFocusedElevation, Level1),
+                hoveredElevation = value(elevationAttrHoveredElevation, Level2),
+                draggedElevation = value(elevationAttrDraggedElevation, Level4),
+                disabledElevation = value(elevationAttrDisabledElevation, Level0),
             )
         }
     }
@@ -610,16 +615,17 @@ internal class ChipDTO private constructor(builder: Builder) :
         return if (elevation == null) {
             defaultElevation
         } else {
-            fun value(key: String) =
-                elevation[key]?.toIntOrNull()?.dp ?: Dp(defaultElevation.privateField(key))
+            fun value(key: String, defValue: Dp) =
+                elevation[key]?.toIntOrNull()?.dp ?: defValue
 
+            val defElevation = elevation[elevationAttrElevation]?.toIntOrNull()?.dp ?: Level0
             InputChipDefaults.inputChipElevation(
-                elevation = value(elevationAttrElevation),
-                pressedElevation = value(elevationAttrPressedElevation),
-                focusedElevation = value(elevationAttrFocusedElevation),
-                hoveredElevation = value(elevationAttrHoveredElevation),
-                draggedElevation = value(elevationAttrDraggedElevation),
-                disabledElevation = value(elevationAttrDisabledElevation),
+                elevation = value(elevationAttrElevation, Level0),
+                pressedElevation = value(elevationAttrPressedElevation, defElevation),
+                focusedElevation = value(elevationAttrFocusedElevation, defElevation),
+                hoveredElevation = value(elevationAttrHoveredElevation, defElevation),
+                draggedElevation = value(elevationAttrDraggedElevation, Level4),
+                disabledElevation = value(elevationAttrDisabledElevation, defElevation),
             )
         }
     }
@@ -630,16 +636,17 @@ internal class ChipDTO private constructor(builder: Builder) :
         return if (elevation == null) {
             defaultElevation
         } else {
-            fun value(key: String) =
-                elevation[key]?.toIntOrNull()?.dp ?: Dp(defaultElevation.privateField(key))
+            fun value(key: String, defaultValue: Dp) =
+                elevation[key]?.toIntOrNull()?.dp ?: defaultValue
 
+            val defElevation = elevation[elevationAttrElevation]?.toIntOrNull()?.dp ?: Level0
             FilterChipDefaults.filterChipElevation(
-                elevation = value(elevationAttrElevation),
-                pressedElevation = value(elevationAttrPressedElevation),
-                focusedElevation = value(elevationAttrFocusedElevation),
-                hoveredElevation = value(elevationAttrHoveredElevation),
-                draggedElevation = value(elevationAttrDraggedElevation),
-                disabledElevation = value(elevationAttrDisabledElevation),
+                elevation = value(elevationAttrElevation, Level0),
+                pressedElevation = value(elevationAttrPressedElevation, Level0),
+                focusedElevation = value(elevationAttrFocusedElevation, Level0),
+                hoveredElevation = value(elevationAttrHoveredElevation, Level1),
+                draggedElevation = value(elevationAttrDraggedElevation, Level4),
+                disabledElevation = value(elevationAttrDisabledElevation, defElevation),
             )
         }
     }
@@ -650,16 +657,16 @@ internal class ChipDTO private constructor(builder: Builder) :
         return if (elevation == null) {
             defaultElevation
         } else {
-            fun value(key: String) =
-                elevation[key]?.toIntOrNull()?.dp ?: Dp(defaultElevation.privateField(key))
+            fun value(key: String, defaultValue: Dp) =
+                elevation[key]?.toIntOrNull()?.dp ?: defaultValue
 
             FilterChipDefaults.elevatedFilterChipElevation(
-                elevation = value(elevationAttrElevation),
-                pressedElevation = value(elevationAttrPressedElevation),
-                focusedElevation = value(elevationAttrFocusedElevation),
-                hoveredElevation = value(elevationAttrHoveredElevation),
-                draggedElevation = value(elevationAttrDraggedElevation),
-                disabledElevation = value(elevationAttrDisabledElevation),
+                elevation = value(elevationAttrElevation, Level1),
+                pressedElevation = value(elevationAttrPressedElevation, Level1),
+                focusedElevation = value(elevationAttrFocusedElevation, Level1),
+                hoveredElevation = value(elevationAttrHoveredElevation, Level2),
+                draggedElevation = value(elevationAttrDraggedElevation, Level4),
+                disabledElevation = value(elevationAttrDisabledElevation, Level0),
             )
         }
     }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/FloatingActionButtonDTO.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/data/dto/FloatingActionButtonDTO.kt
@@ -23,6 +23,8 @@ import org.phoenixframework.liveview.data.constants.Attrs.attrElevation
 import org.phoenixframework.liveview.data.constants.Attrs.attrExpanded
 import org.phoenixframework.liveview.data.constants.Attrs.attrPhxClick
 import org.phoenixframework.liveview.data.constants.Attrs.attrShape
+import org.phoenixframework.liveview.data.constants.DefaultElevationValues.Level3
+import org.phoenixframework.liveview.data.constants.DefaultElevationValues.Level4
 import org.phoenixframework.liveview.data.constants.ElevationAttrs.elevationAttrDefaultElevation
 import org.phoenixframework.liveview.data.constants.ElevationAttrs.elevationAttrFocusedElevation
 import org.phoenixframework.liveview.data.constants.ElevationAttrs.elevationAttrHoveredElevation
@@ -34,7 +36,6 @@ import org.phoenixframework.liveview.domain.base.ComposableTypes
 import org.phoenixframework.liveview.domain.base.ComposableView
 import org.phoenixframework.liveview.domain.base.ComposableViewFactory
 import org.phoenixframework.liveview.domain.base.PushEvent
-import org.phoenixframework.liveview.domain.extensions.privateField
 import org.phoenixframework.liveview.domain.extensions.toColor
 import org.phoenixframework.liveview.domain.factory.ComposableTreeNode
 import org.phoenixframework.liveview.ui.phx_components.PhxLiveView
@@ -149,18 +150,18 @@ internal class FloatingActionButtonDTO private constructor(builder: Builder) :
 
     @Composable
     private fun getFabElevation(elevation: ImmutableMap<String, String>?): FloatingActionButtonElevation {
-        val defaultValue = FloatingActionButtonDefaults.elevation()
+        val defaultElevation = FloatingActionButtonDefaults.elevation()
         return if (elevation == null) {
-            defaultValue
+            defaultElevation
         } else {
-            fun value(key: String) =
-                elevation[key]?.toIntOrNull()?.dp ?: Dp(defaultValue.privateField(key))
+            fun value(key: String, defaultValue: Dp) =
+                elevation[key]?.toIntOrNull()?.dp ?: defaultValue
 
             FloatingActionButtonDefaults.elevation(
-                defaultElevation = value(elevationAttrDefaultElevation),
-                pressedElevation = value(elevationAttrPressedElevation),
-                focusedElevation = value(elevationAttrFocusedElevation),
-                hoveredElevation = value(elevationAttrHoveredElevation),
+                defaultElevation = value(elevationAttrDefaultElevation, Level3),
+                pressedElevation = value(elevationAttrPressedElevation, Level3),
+                focusedElevation = value(elevationAttrFocusedElevation, Level3),
+                hoveredElevation = value(elevationAttrHoveredElevation, Level4),
             )
         }
     }

--- a/liveview-android/src/main/java/org/phoenixframework/liveview/domain/extensions/Extensions.kt
+++ b/liveview-android/src/main/java/org/phoenixframework/liveview/domain/extensions/Extensions.kt
@@ -36,12 +36,3 @@ internal fun String.toColor(): Color {
     }
 
 }
-
-// TODO This extension is using reflexion to get default values for different component's properties
-internal fun <T> Any.privateField(name: String): T {
-    val field = this::class.java.getDeclaredField(name).apply {
-        isAccessible = true
-    }
-    @Suppress("UNCHECKED_CAST")
-    return field.get(this) as T
-}


### PR DESCRIPTION
This PR includes a fix for issue #407.

I was using reflection to get the default value for elevations, but it was not necessary anymore, so I'm removing it.