### PR TITLE
rules parser import along with kotlin + jetpack changes

### DIFF
--- a/lib/live_view_native/jetpack/rules_parser.ex
+++ b/lib/live_view_native/jetpack/rules_parser.ex
@@ -1,5 +1,6 @@
 defmodule LiveViewNative.Jetpack.RulesParser do
   @moduledoc false
+
   alias LiveViewNative.Jetpack.RulesParser.Modifiers
   alias LiveViewNative.Jetpack.RulesParser.Parser
 
@@ -28,7 +29,7 @@ defmodule LiveViewNative.Jetpack.RulesParser do
       |> Keyword.put(:module, module)
       |> Keyword.put(:line, line)
 
-      result =
+    result =
       rules
       |> Modifiers.modifiers(opts)
       |> Parser.error_from_result()

--- a/lib/live_view_native/jetpack/rules_parser/expressions.ex
+++ b/lib/live_view_native/jetpack/rules_parser/expressions.ex
@@ -36,7 +36,7 @@ defmodule LiveViewNative.Jetpack.RulesParser.Expressions do
     Enum.reduce(combinators, empty(), &concat(&2, &1))
   end
 
-  defp swift_range(combinator) do
+  defp kotlin_range(combinator) do
     nil_ = replace(empty(), nil)
 
     choice([
@@ -51,10 +51,10 @@ defmodule LiveViewNative.Jetpack.RulesParser.Expressions do
       # foo(..<Baz.qux)
       seq([nil_, string("..<"), combinator])
     ])
-    |> post_traverse({PostProcessors, :to_swift_range_ast, []})
+    |> post_traverse({PostProcessors, :to_kotlin_range_ast, []})
   end
 
-  def swift_range() do
+  def kotlin_range() do
     scoped_atom =
       type_name(generate_error?: false)
       |> ignore(string("."))
@@ -62,9 +62,9 @@ defmodule LiveViewNative.Jetpack.RulesParser.Expressions do
       |> post_traverse({PostProcessors, :to_scoped_atom, []})
 
     choice([
-      swift_range(scoped_atom),
-      swift_range(integer()),
-      swift_range(double_quoted_string())
+      kotlin_range(scoped_atom),
+      kotlin_range(integer()),
+      kotlin_range(double_quoted_string())
     ])
   end
 

--- a/lib/live_view_native/jetpack/rules_parser/expressions.ex
+++ b/lib/live_view_native/jetpack/rules_parser/expressions.ex
@@ -103,16 +103,20 @@ defmodule LiveViewNative.Jetpack.RulesParser.Expressions do
     end
   end
 
-  def key_value_pair(opts \\ []) do
+  def key_value_pair(connector, opts \\ []) do
     colon =
       if opts[:generate_error?] do
         # require that the colon be provided
-        expect(ignore(string(":")), error_message: "expected ‘:’")
+        expect(ignore(string(connector)), error_message: "expected ‘#{connector}’")
       else
-        ignore(string(":"))
+        ignore(string(connector))
       end
 
-    key = concat(word(), colon)
+    key =
+      word()
+      |> concat(ignore_whitespace())
+      |> concat(colon)
+
     value = parsec(:key_value_pairs_arguments)
 
     ignore_whitespace()
@@ -122,7 +126,18 @@ defmodule LiveViewNative.Jetpack.RulesParser.Expressions do
     |> post_traverse({PostProcessors, :to_keyword_tuple_ast, []})
   end
 
-  def key_value_pairs(opts \\ []) do
-    wrap(comma_separated_list(key_value_pair(opts), opts))
+  def key_value_pairs(connector, opts \\ []) do
+    wrap(
+      # Match first pair
+      key_value_pair(connector, Keyword.put(opts, :generate_error?, false))
+      |> choice([
+        # then try for more pairs
+        ignore(string(","))
+        |> ignore_whitespace()
+        |> concat(comma_separated_list(key_value_pair(connector, opts), opts)),
+        # otherwise, stop
+        ignore_whitespace()
+      ])
+    )
   end
 end

--- a/lib/live_view_native/jetpack/rules_parser/modifiers.ex
+++ b/lib/live_view_native/jetpack/rules_parser/modifiers.ex
@@ -200,8 +200,8 @@ defmodule LiveViewNative.Jetpack.RulesParser.Modifiers do
         inside_key_value_pair?
       },
       {
-        swift_range(),
-        ~s'a Swift range eg ‘1..<10’ or ‘foo(Foo.bar...Baz.qux)’'
+        kotlin_range(),
+        ~s'a Kotlin range eg ‘1..<10’ or ‘foo(Foo.bar...Baz.qux)’'
       },
       {
         literal(error_parser: empty(), generate_error?: false),

--- a/lib/live_view_native/jetpack/rules_parser/parser.ex
+++ b/lib/live_view_native/jetpack/rules_parser/parser.ex
@@ -13,6 +13,7 @@ defmodule LiveViewNative.Jetpack.RulesParser.Parser do
     {_, names} = Enum.unzip(named_choices)
 
     names
+    |> Enum.filter(& &1)
     |> Enum.map(&(" - " <> &1))
     |> Enum.join("\n")
   end

--- a/lib/live_view_native/jetpack/rules_parser/parser.ex
+++ b/lib/live_view_native/jetpack/rules_parser/parser.ex
@@ -1,5 +1,6 @@
 defmodule LiveViewNative.Jetpack.RulesParser.Parser do
   @moduledoc false
+
   import NimbleParsec
   alias LiveViewNative.Jetpack.RulesParser.Parser.Context
   alias LiveViewNative.Jetpack.RulesParser.Parser.Error

--- a/lib/live_view_native/jetpack/rules_parser/parser/context.ex
+++ b/lib/live_view_native/jetpack/rules_parser/parser/context.ex
@@ -1,5 +1,6 @@
 defmodule LiveViewNative.Jetpack.RulesParser.Parser.Context do
   @moduledoc false
+
   defstruct [
     :file,
     :annotations,

--- a/lib/live_view_native/jetpack/rules_parser/parser/error.ex
+++ b/lib/live_view_native/jetpack/rules_parser/parser/error.ex
@@ -1,5 +1,6 @@
 defmodule LiveViewNative.Jetpack.RulesParser.Parser.Error do
   @moduledoc false
+
   alias LiveViewNative.Jetpack.RulesParser.Parser.Context
 
   defstruct([

--- a/lib/live_view_native/jetpack/rules_parser/post_processors.ex
+++ b/lib/live_view_native/jetpack/rules_parser/post_processors.ex
@@ -10,19 +10,19 @@ defmodule LiveViewNative.Jetpack.RulesParser.PostProcessors do
       empty()
       |> PostProcessors.inspect()
       |> combinator
-      |> PostProcessors.inspect()
+      |> PostProcessors.inspect(label: "combinator")
 
     This function is extremely useful for debugging, do not remove
     """
-    def inspect(combinator) do
+    def inspect(combinator, opts \\ []) do
       NimbleParsec.pre_traverse(
         combinator,
-        {LiveViewNative.Jetpack.RulesParser.PostProcessors, :do_inspect, []}
+        {LiveViewNative.Jetpack.RulesParser.PostProcessors, :do_inspect, [opts]}
       )
     end
 
-    def do_inspect(rest, args, context, position, _byte_offset) do
-      IO.inspect({rest, args, context, position})
+    def do_inspect(rest, args, context, position, _byte_offset, opts) do
+      IO.inspect({rest, args, context, position}, opts)
       {rest, args, context}
     end
   end
@@ -158,6 +158,10 @@ defmodule LiveViewNative.Jetpack.RulesParser.PostProcessors do
       ) do
     annotations = context_to_annotation(context.context, line)
     {rest, [{Elixir, annotations, {:to_atom, variable_annotations, [variable]}}], context}
+  end
+
+  def number_ime(rest, [member_expression, number], context, {_line, _}, _byte_offset) do
+    {rest, [{:., [number, member_expression]}], context}
   end
 
   def to_keyword_tuple_ast(rest, [arg1, arg2], context, {_line, _}, _byte_offset) do

--- a/lib/live_view_native/jetpack/rules_parser/post_processors.ex
+++ b/lib/live_view_native/jetpack/rules_parser/post_processors.ex
@@ -193,7 +193,7 @@ defmodule LiveViewNative.Jetpack.RulesParser.PostProcessors do
     {rest, [{:., annotations, [String.to_atom(scope), String.to_atom(variable_name)]}], context}
   end
 
-  def to_swift_range_ast(rest, [end_, range, start], context, {line, _}, _byte_offset) do
+  def to_kotlin_range_ast(rest, [end_, range, start], context, {line, _}, _byte_offset) do
     annotations = context_to_annotation(context.context, line)
     {rest, [{String.to_atom(range), annotations, [start, end_]}], context}
   end

--- a/lib/live_view_native/jetpack/rules_parser/tokens.ex
+++ b/lib/live_view_native/jetpack/rules_parser/tokens.ex
@@ -1,5 +1,6 @@
 defmodule LiveViewNative.Jetpack.RulesParser.Tokens do
   @moduledoc false
+
   import NimbleParsec
   import LiveViewNative.Jetpack.RulesParser.Parser
   alias LiveViewNative.Jetpack.RulesParser.PostProcessors

--- a/test/live_view_native/jetpack/rules_parser_test.exs
+++ b/test/live_view_native/jetpack/rules_parser_test.exs
@@ -429,13 +429,15 @@ defmodule LiveViewNative.Jetpack.RulesParserTest do
           |
 
         Expected ‘()’ or ‘(<modifier_arguments>)’ where <modifier_arguments> are a comma separated list of:
-         - a list of values eg ‘[1, 2, 3]’, ‘["red", "blue"]’ or ‘[Color.red, Color.blue]’
-         - a Swift range eg ‘1..<10’ or ‘foo(Foo.bar...Baz.qux)’
+         - a list of values eg ‘[1, 2, 3]’, ‘[\"red\", \"blue\"]’ or ‘[Color.red, Color.blue]’
+         - a Kotlin range eg ‘1..<10’ or ‘foo(Foo.bar...Baz.qux)’
+         - an IME eg ‘Color.red’ or ‘.largeTitle’’
          - a number, string, nil, boolean or :atom
          - an event eg ‘event(\"search-event\", throttle: 10_000)’
          - an attribute eg ‘attr(\"placeholder\")’
          - an IME eg ‘Color.red’ or ‘.largeTitle’’
          - a list of keyword pairs eg ‘style: :dashed’, ‘size: 12’ or  ‘style: [lineWidth: 1]’
+         - a list of keyword pairs eg ‘style = dashed’, ‘size = 12’ or  ‘style = [lineWidth = 1]’
          - a modifier eg ‘bold()’
          - a variable defined in the class header eg ‘color_name’
         """
@@ -513,7 +515,7 @@ defmodule LiveViewNative.Jetpack.RulesParserTest do
       assert String.trim(error.description) == error_prefix
     end
 
-    test "invalid keyword pair: missing colon" do
+    test "invalid keyword pair: missing equals" do
       input = "abc(def = 11, b = [lineWidth a, l = 2a])"
 
       error =
@@ -525,11 +527,22 @@ defmodule LiveViewNative.Jetpack.RulesParserTest do
         """
         Unsupported input:
           |
-        1 | abc(def = 11, b = [lineWidth‎ a, l = 2a])
-          |                           ^
+        1 | abc(def = 11, b = [lineWidth a, l = 2a])
+          |                   ^^^^^^^^^^
           |
 
-        expected ‘:’
+        Expected one of the following:
+         - a list of values eg ‘[1, 2, 3]’, ‘[\"red\", \"blue\"]’ or ‘[Color.red, Color.blue]’
+         - a keyword list eg ‘[style: :dashed]’, ‘[size: 12]’ or ‘[lineWidth: lineWidth]’
+         - a keyword list eg ‘[style = dashed]’, ‘[size = 12]’ or ‘[lineWidth = lineWidth]’
+         - a Kotlin range eg ‘1..<10’ or ‘foo(Foo.bar...Baz.qux)’
+         - an IME eg ‘Color.red’ or ‘.largeTitle’’
+         - a number, string, nil, boolean or :atom
+         - an event eg ‘event(\"search-event\", throttle: 10_000)’
+         - an attribute eg ‘attr(\"placeholder\")’
+         - an IME eg ‘Color.red’ or ‘.largeTitle’’
+         - a modifier eg ‘bold()’
+         - a variable defined in the class header eg ‘color_name’
         """
         |> String.trim()
 
@@ -537,7 +550,7 @@ defmodule LiveViewNative.Jetpack.RulesParserTest do
     end
 
     test "invalid keyword pair: double nesting" do
-      input = "abc(def = 11, b = lineWidth: a, l = 2a]"
+      input = "abc(def = 11, b = lineWidth = a, l = 2a]"
 
       error =
         assert_raise SyntaxError, fn ->
@@ -549,7 +562,7 @@ defmodule LiveViewNative.Jetpack.RulesParserTest do
         Unsupported input:
           |
         1 | abc(def = 11, b = lineWidth = a, l = 2a]
-          |                          ^
+          |                             ^
           |
 
         expected ‘)’
@@ -572,7 +585,7 @@ defmodule LiveViewNative.Jetpack.RulesParserTest do
         Unsupported input:
           |
         1 | abc(def = 11, b = [lineWidth = 1lineWidth])
-          |                              ^^^^^^^^^
+          |                                 ^^^^^^^^^
           |
 
         Invalid suffix on number
@@ -595,7 +608,7 @@ defmodule LiveViewNative.Jetpack.RulesParserTest do
         Unsupported input:
           |
         1 | abc(def = 11, b = [lineWidth = :1])
-          |                              ^
+          |                                 ^
           |
 
         Expected an atom, but got ‘1’
@@ -618,7 +631,7 @@ defmodule LiveViewNative.Jetpack.RulesParserTest do
         Unsupported input:
           |
         1 | abc(def = 11, b = :1)
-          |                  ^
+          |                    ^
           |
 
         Expected an atom, but got ‘1’
@@ -641,7 +654,7 @@ defmodule LiveViewNative.Jetpack.RulesParserTest do
         Unsupported input:
           |
         1 | abc(def = 11, b = [lineWidth = 1)
-          |                              ^
+          |                                 ^
           |
 
         expected ‘]’
@@ -691,13 +704,15 @@ defmodule LiveViewNative.Jetpack.RulesParserTest do
           |
 
         Expected one of the following:
-         - a list of values eg ‘[1, 2, 3]’, ‘["red", "blue"]’ or ‘[Color.red, Color.blue]’
-         - a Swift range eg ‘1..<10’ or ‘foo(Foo.bar...Baz.qux)’
+         - a list of values eg ‘[1, 2, 3]’, ‘[\"red\", \"blue\"]’ or ‘[Color.red, Color.blue]’
+         - a Kotlin range eg ‘1..<10’ or ‘foo(Foo.bar...Baz.qux)’
+         - an IME eg ‘Color.red’ or ‘.largeTitle’’
          - a number, string, nil, boolean or :atom
-         - an event eg ‘event("search-event", throttle: 10_000)’
-         - an attribute eg ‘attr("placeholder")’
+         - an event eg ‘event(\"search-event\", throttle: 10_000)’
+         - an attribute eg ‘attr(\"placeholder\")’
          - an IME eg ‘Color.red’ or ‘.largeTitle’’
          - a list of keyword pairs eg ‘style: :dashed’, ‘size: 12’ or  ‘style: [lineWidth: 1]’
+         - a list of keyword pairs eg ‘style = dashed’, ‘size = 12’ or  ‘style = [lineWidth = 1]’
          - a modifier eg ‘bold()’
          - a variable defined in the class header eg ‘color_name’
         """

--- a/test/live_view_native/jetpack/rules_parser_test.exs
+++ b/test/live_view_native/jetpack/rules_parser_test.exs
@@ -238,9 +238,16 @@ defmodule LiveViewNative.Jetpack.RulesParserTest do
       assert parse(input) == output
     end
 
-    test "parses Implicit Member Expressions" do
+    test "parses member expressions" do
       input = "color(.red)"
       output = {:color, [], [{:., [], [nil, :red]}]}
+
+      assert parse(input) == output
+    end
+
+    test "numerical member expressions" do
+      input = "textSize(1.dp, 10.5.em)"
+      output = {:textSize, [], [{:., [1, :dp]}, {:., [10.5, :em]}]}
 
       assert parse(input) == output
     end


### PR DESCRIPTION
Closes #422 

@NduatiK I'll assign to you. There are new failing tests to meet the needs of the Jetpack client library + kotlin syntax.

After this is green and merged it would be great to extract the common code between this and the SwiftUI lib back into the Stylesheet lib