### PR TITLE
Support atom aliases

### DIFF
--- a/lib/live_view_native/jetpack/rules_parser/modifiers.ex
+++ b/lib/live_view_native/jetpack/rules_parser/modifiers.ex
@@ -244,6 +244,7 @@ defmodule LiveViewNative.Jetpack.RulesParser.Modifiers do
         ~s'an IME eg ‘Color.red’ or ‘.largeTitle’’'
       },
       {
+        # Must come after :ime parser
         literal(error_parser: empty(), generate_error?: false),
         ~s'a number, string, nil, boolean or :atom'
       },

--- a/lib/live_view_native/jetpack/rules_parser/tokens.ex
+++ b/lib/live_view_native/jetpack/rules_parser/tokens.ex
@@ -67,24 +67,32 @@ defmodule LiveViewNative.Jetpack.RulesParser.Tokens do
   end
 
   def atom() do
-    ignore(string(":"))
-    |> concat(
-      choice([
-        double_quoted_string(),
-        variable_name()
-      ])
-      |> expect(
-        error_message: "Expected an atom",
-        error_parser:
-          choice([
-            non_whitespace(also_ignore: String.to_charlist("[](),"), fail_if_empty: true),
-            non_whitespace(also_ignore: String.to_charlist("]),"), fail_if_empty: true),
-            non_whitespace()
-          ]),
-        show_incorrect_text?: true
+    choice([
+      # Match CircleShape or Color
+      ascii_string([?A..?Z], 1)
+      |> ascii_string([?a..?z, ?A..?Z, ?0..?9, ?_], min: 0)
+      |> reduce({Enum, :join, [""]})
+      |> map({String, :to_atom, []}),
+      # Match :round or :red
+      ignore(string(":"))
+      |> concat(
+        choice([
+          double_quoted_string(),
+          variable_name()
+        ])
+        |> expect(
+          error_message: "Expected an atom",
+          error_parser:
+            choice([
+              non_whitespace(also_ignore: String.to_charlist("[](),"), fail_if_empty: true),
+              non_whitespace(also_ignore: String.to_charlist("]),"), fail_if_empty: true),
+              non_whitespace()
+            ]),
+          show_incorrect_text?: true
+        )
       )
-    )
-    |> map({String, :to_atom, []})
+      |> map({String, :to_atom, []})
+    ])
   end
 
   def double_quoted_string() do

--- a/test/live_view_native/jetpack/rules_parser_test.exs
+++ b/test/live_view_native/jetpack/rules_parser_test.exs
@@ -106,6 +106,14 @@ defmodule LiveViewNative.Jetpack.RulesParserTest do
       assert parse(input) == output
     end
 
+    test "parses atoms" do
+      input = "background(Color.Green, CircleShape)"
+
+      output = {:background, [], [{:., [], [:Color, :Green]}, :CircleShape]}
+
+      assert parse(input) == output
+    end
+
     test "parses chained IMEs" do
       input = "font(color: Color.red)"
 


### PR DESCRIPTION
Closes #447

We were not handling atom aliases (atoms starting with uppercase and no `:`)