### PR TITLE
Added dependabot for github actions and updated actions versions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"] # ignore patch updates

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'


### PR DESCRIPTION
I discovered and started using [actionlint](https://github.com/rhysd/actionlint) as it's been very helpful. I end up running on any repo I touch now.

Anyway, it informed me that the `checkout` and `java-setup` actions were a bit out of date. I think they use node 12 by default with those versions.

I've updated those github action versions and added dependabot to just update github actions so that we don't need to do this manually in the future.