### PR TITLE
Modifiers parsing performance improvements

### DIFF
--- a/liveview-android/src/test/java/com/dockyard/liveviewtest/liveview/ui/modifiers/ModifiersParserTest.kt
+++ b/liveview-android/src/test/java/com/dockyard/liveviewtest/liveview/ui/modifiers/ModifiersParserTest.kt
@@ -25,7 +25,7 @@ class ModifiersParserTest : ModifierBaseTest() {
 
     @Test
     fun parseFileWithEmptyMapTest() {
-        ModifiersParser.fromStyleFile("")
+        ModifiersParser.fromStyleFile("%{}")
         assert(ModifiersParser.isEmpty)
     }
 

--- a/stylesheet-parser/build.gradle
+++ b/stylesheet-parser/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 
 generateGrammarSource {
     maxHeapSize = "128m"
-    arguments += ['-package', 'org.phoenixframework.liveview.stylesheet', '-visitor']
+    arguments += ['-package', 'org.phoenixframework.liveview.stylesheet', '-no-visitor', '-no-listener']
     outputDirectory = new File(buildDir.toString() +'/'+ outputDir)
 }
 compileJava.dependsOn generateGrammarSource

--- a/stylesheet-parser/src/main/antlr/ElixirLexer.g4
+++ b/stylesheet-parser/src/main/antlr/ElixirLexer.g4
@@ -15,31 +15,9 @@ ATOM: ':' ( [\p{L}_] [\p{L}_0-9@]* [!?]? | OPERATOR | SINGLE_LINE_STRING | SINGL
 TRUE  : 'true';
 FALSE : 'false';
 NIL   : 'nil';
-WHEN  : 'when';
-AND   : 'and';
-OR    : 'or';
-NOT   : 'not';
-IN    : 'in';
-FN    : 'fn';
-DO    : 'do';
 END   : 'end';
-CATCH : 'catch';
-RECUE : 'rescue';
 AFTER : 'after';
-ELSE  : 'else';
 
-// Non-keywords, which also need to be included in the `variable` parser rule
-CASE      : 'case';
-COND      : 'cond';
-IF        : 'if';
-UNLESS    : 'unless';
-DEFMODULE : 'defmodule';
-DEFMACRO  : 'defmacro';
-DEF       : 'def';
-DEFP      : 'defp';
-FOR       : 'for';
-WITH      : 'with';
-TRY       : 'try';
 
 CODEPOINT: '?' ( '\\' . | ~[\\]);
 
@@ -74,51 +52,13 @@ ALIAS: [A-Z] [a-zA-Z_0-9]*;
 
 VARIABLE: [\p{Ll}_] [\p{L}_0-9]* [!?]?;
 
-AT          : '@';
 DOT         : '.';
-EXCL        : '!';
-CARET       : '^';
-TILDE3      : '~~~';
-MUL         : '*';
-DIV         : '/';
 ADD         : '+';
 SUB         : '-';
-ADD2        : '++';
-SUB2        : '--';
-ADD3        : '+++';
-SUB3        : '---';
 DOT2        : '..';
-LTGT        : '<>';
-PIPE_GT     : '|>';
-LT3         : '<<<';
-GT3         : '>>>';
-GT2_TILDE   : '<<~';
-TILDE_GT2   : '~>>';
-LT_TILDE    : '<~';
-TILDE_GT    : '~>';
-LT_TILDE_GT : '<~>';
-LT_PIPE_GT  : '<|>';
-LT          : '<';
-GT          : '>';
-LT_EQ       : '<=';
-GT_EQ       : '>=';
-EQ2         : '==';
-EXCL_EQ     : '!=';
-EQ_TILDE    : '=~';
-EQ3         : '===';
-EXCL_EQ2    : '!==';
-AMP2        : '&&';
-AMP3        : '&&&';
-PIPE2       : '||';
-PIPE3       : '|||';
 EQ          : '=';
-AMP         : '&';
 ARROW       : '=>';
 PIPE        : '|';
-COL2        : '::';
-LARROW      : '<-';
-RARROW      : '->';
-BSLASH2     : '\\\\';
 
 OPAR   : '(';
 CPAR   : ')';
@@ -134,49 +74,12 @@ COL    : ':';
 SCOL   : ';';
 
 fragment OPERATOR:
-    AT
-    | DOT
-    | EXCL
-    | CARET
-    | SUB3
-    | MUL
-    | DIV
+    DOT
     | ADD
     | SUB
-    | ADD2
-    | SUB2
-    | ADD3
     | DOT2
-    | LTGT
-    | PIPE_GT
-    | LT3
-    | GT3
-    | GT2_TILDE
-    | TILDE_GT2
-    | LT_TILDE
-    | TILDE_GT
-    | LT_TILDE_GT
-    | LT_PIPE_GT
-    | LT
-    | GT
-    | LT_EQ
-    | GT_EQ
-    | EQ2
-    | EXCL_EQ
-    | EQ_TILDE
-    | EQ3
-    | EXCL_EQ2
-    | AMP2
-    | AMP3
-    | PIPE2
-    | PIPE3
     | EQ
-    | AMP
     | PIPE
-    | COL2
-    | LARROW
-    | RARROW
-    | BSLASH2
 ;
 
 fragment D        : [0-9];

--- a/stylesheet-parser/src/main/antlr/ElixirLexer.g4
+++ b/stylesheet-parser/src/main/antlr/ElixirLexer.g4
@@ -15,9 +15,6 @@ ATOM: ':' ( [\p{L}_] [\p{L}_0-9@]* [!?]? | OPERATOR | SINGLE_LINE_STRING | SINGL
 TRUE  : 'true';
 FALSE : 'false';
 NIL   : 'nil';
-END   : 'end';
-AFTER : 'after';
-
 
 CODEPOINT: '?' ( '\\' . | ~[\\]);
 
@@ -53,7 +50,6 @@ ALIAS: [A-Z] [a-zA-Z_0-9]*;
 VARIABLE: [\p{Ll}_] [\p{L}_0-9]* [!?]?;
 
 DOT         : '.';
-ADD         : '+';
 SUB         : '-';
 DOT2        : '..';
 EQ          : '=';
@@ -66,8 +62,6 @@ OBRACK : '[';
 CBRACK : ']';
 OBRACE : '{';
 CBRACE : '}';
-LT1    : '<<';
-GT2    : '>>';
 OMAP   : '%' ( [a-zA-Z_.] [a-zA-Z_.0-9]*)? '{';
 COMMA  : ',';
 COL    : ':';
@@ -75,7 +69,6 @@ SCOL   : ';';
 
 fragment OPERATOR:
     DOT
-    | ADD
     | SUB
     | DOT2
     | EQ

--- a/stylesheet-parser/src/main/antlr/ElixirLexer.g4
+++ b/stylesheet-parser/src/main/antlr/ElixirLexer.g4
@@ -16,24 +16,6 @@ TRUE  : 'true';
 FALSE : 'false';
 NIL   : 'nil';
 
-CODEPOINT: '?' ( '\\' . | ~[\\]);
-
-SIGIL:
-    '~' [a-zA-Z] (
-        '/' ( ESCAPE | '\\/' | ~[/\\])* '/'
-        | '|' ( ESCAPE | '\\|' | ~[|\\])* '|'
-        | SINGLE_LINE_STRING
-        | MULTI_LINE_STRING
-        | SINGLE_LINE_CHARLIST
-        | MULTI_LINE_CHARLIST
-        | '\'' ( ESCAPE | '\\\'' | ~['\\])* '\''
-        | '(' ( ESCAPE | '\\)' | ~[)\\])* ')'
-        | '[' ( ESCAPE | '\\]' | ~[\]\\])* ']'
-        | '{' ( ESCAPE | '\\}' | ~[}\\])* '}'
-        | '<' ( ESCAPE | '\\>' | ~[>\\])* '>'
-    ) [a-zA-Z]*
-;
-
 HEXADECIMAL : '0x' HEX+ ( '_' HEX+)*;
 OCTAL       : '0o' [0-7]+ ( '_' [0-7]+)*;
 BINARY      : '0b' [01]+ ( '_' [01]+)*;

--- a/stylesheet-parser/src/main/antlr/ElixirParser.g4
+++ b/stylesheet-parser/src/main/antlr/ElixirParser.g4
@@ -21,52 +21,13 @@ eoe
 
 expression
     : expression expression_tail                                   # dotExpr
-    | expression '.'? '(' (expressions_ ( ',' NL* options_)?)? ')' # functionCallExpr
-    | expression '.'? '(' NL* options_ NL* ')'                     # functionCallExpr
-    | module_def                                                   # moduleDefExpr
-    | function_def                                                 # functionDefExpr
-    | macro_def                                                    # macroDefExpr
-    | for                                                          # forExpr
-    | with                                                         # withExpr
-    | try                                                          # tryExpr
-    | expression expressions_ ( ',' NL* options_)?                 # functionCallExpr
-    | expression options_? expressions_                            # functionCallExpr
-    | expression options_                                          # functionCallExpr
-    | anonymous_function                                           # anonymousFunctionExpr
     | '(' expression ')'                                           # nestedExpr
-    | '@' expression options_?                                     # atExpr
     | unaryOp expression                                           # unaryExpr
-    | expression mulOp expression                                  # mulExpr
-    | expression addOp expression                                  # addExpr
-    | expression listOp expression                                 # listExpr
-    | expression inOp expression                                   # inExpr
-    | expression '|>' expression                                   # pipeExpr
-    | expression otherOp expression                                # otherExpr
-    | expression bitOp expression                                  # bitExpr
-    | expression relOp expression                                  # relExpr
-    | expression eqOp expression                                   # eqExpr
-    | expression andOp expression                                  # andExpr
-    | expression orOp expression                                   # orExpr
     | expression '=' expression                                    # patternExpr
-    | '&' expression                                               # ampExpr
-    | expression '|' expression                                    # prependExpr
-    | expression '::' expression                                   # typeExpr
-    | expression WHEN expression                                   # whenExpr
-    | expression '\\\\' expression                                 # defaultValueExpr
-    | expression '->' NL* expression                               # rarrowExpr
-    | expression '<-' expression                                   # larrowExpr
     | list                                                         # listExpr
     | tuple                                                        # tupleExpr
     | map                                                          # mapExpr
     | bool_                                                        # boolExpr
-    | bitstring                                                    # bitstringExpr
-    | case                                                         # caseExpr
-    | cond                                                         # condExpr
-    | if                                                           # ifExpr
-    | unless                                                       # unlessExpr
-    | operator                                                     # operatorExpr
-    | do_block                                                     # doBlockExpr
-    | variables                                                    # variablesExpr
     | ATOM                                                         # atomExpr
     | INTEGER                                                      # integerExpr
     | HEXADECIMAL                                                  # hexadecimalExpr
@@ -86,99 +47,11 @@ expression
 unaryOp
     : '+'
     | '-'
-    | '!'
-    | '^'
-    | 'not'
-    | '~~~'
-    ;
-
-mulOp
-    : '*'
-    | '/'
-    ;
-
-addOp
-    : '+'
-    | '-'
-    ;
-
-listOp
-    : '++'
-    | '--'
-    | '+++'
-    | '---'
-    | '..'
-    | '<>'
-    ;
-
-inOp
-    : 'in'
-    | 'not' 'in'
-    ;
-
-relOp
-    : '<'
-    | '>'
-    | '<='
-    | '>='
-    ;
-
-eqOp
-    : '=='
-    | '!='
-    | '=~'
-    | '==='
-    | '!=='
-    ;
-
-andOp
-    : '&&'
-    | '&&&'
-    | 'and'
-    ;
-
-orOp
-    : '||'
-    | '|||'
-    | 'or'
-    ;
-
-bitOp
-    : '<<<'
-    | '>>>'
-    ;
-
-otherOp
-    : '<<~'
-    | '~>>'
-    | '<~'
-    | '~>'
-    | '<~>'
-    | '<|>'
-    ;
-
-// TODO add literals
-operator
-    : unaryOp
-    | mulOp
-    | addOp
-    | listOp
-    | inOp
-    | relOp
-    | eqOp
-    | andOp
-    | orOp
-    | bitOp
-    | otherOp
     ;
 
 expression_tail
     : '[' expression ']'
     | '.' expression
-    ;
-
-do_block
-    : DO NL* block? NL* (AFTER NL* block NL*)? END
     ;
 
 bool_
@@ -225,56 +98,6 @@ short_map_entry
     // variable ':' expression
     ;
 
-anonymous_function
-    : FN NL* expressions_? '->' NL* block? NL* END
-    | FN '(' expressions_? ')' '->' NL* block? NL* END
-    ;
-
-case
-    : CASE expression DO NL+ condition+ END
-    ;
-
-condition
-    : expression '->' NL* expression NL+
-    ;
-
-cond
-    : COND DO NL+ condition+ END
-    ;
-
-if
-    : IF expression DO NL* block NL* (ELSE NL* block NL*)? END
-    | IF expression ',' NL* DO ':' NL* expression (',' NL* ELSE ':' NL* expression)?
-    ;
-
-unless
-    : UNLESS expression do_block
-    ;
-
-bitstring
-    : '<<' (expressions_ ','?)? '>>'
-    ;
-
-module_def
-    : DEFMODULE ALIAS do_block
-    ;
-
-function_def
-    : (DEF | DEFP) variable ('(' expressions_? ')')+ (WHEN expression)? do_block
-    | (DEF | DEFP) variable ('(' expressions_? ')')+ (WHEN expression)? ',' DO ':' expression
-    | ( DEF | DEFP) variable ',' DO ':' expression
-    ;
-
-macro_def
-    : DEFMACRO variable '(' expressions_? ')' (WHEN expression)? do_block
-    | DEFMACRO variable '(' expressions_? ')' (WHEN expression)? ',' DO ':' expression
-    ;
-
-for
-    : FOR expressions_ (',' NL* options_)? do_block
-    | FOR expressions_ ( ',' NL* options_)? ',' DO ':' NL* expression
-    ;
-
 options_
     : option (',' NL* option)*
     ;
@@ -283,33 +106,10 @@ option
     : variable ':' expression
     ;
 
-with
-    : WITH expressions_ do_block
-    ;
-
-try
-    : TRY DO NL* block (RECUE | CATCH | AFTER) NL* expressions_ (NL* block)? (NL* ELSE NL* block)? NL* END
-    ;
-
 expressions_
     : expression (',' NL* expression)*
     ;
 
-variables
-    : variable (',' NL* variable)*
-    ;
-
 variable
     : VARIABLE
-    | CASE
-    | COND
-    | IF
-    | UNLESS
-    | DEFMODULE
-    | DEFMACRO
-    | DEF
-    | DEFP
-    | FOR
-    | WITH
-    | TRY
     ;

--- a/stylesheet-parser/src/main/antlr/ElixirParser.g4
+++ b/stylesheet-parser/src/main/antlr/ElixirParser.g4
@@ -45,8 +45,7 @@ expression
     ;
 
 unaryOp
-    : '+'
-    | '-'
+    : '-'
     ;
 
 expression_tail
@@ -94,8 +93,7 @@ short_map_entries
     ;
 
 short_map_entry
-    : (variable | END | AFTER) ':' expression  // Change to allow named params uses "end" and "after"
-    // variable ':' expression
+    : variable ':' expression
     ;
 
 options_

--- a/stylesheet-parser/src/main/antlr/ElixirParser.g4
+++ b/stylesheet-parser/src/main/antlr/ElixirParser.g4
@@ -34,13 +34,11 @@ expression
     | OCTAL                                                        # octalExpr
     | BINARY                                                       # binaryExpr
     | FLOAT                                                        # floatExpr
-    | SIGIL                                                        # sigilExpr
     | SINGLE_LINE_STRING                                           # singleLineStringExpr
     | MULTI_LINE_STRING                                            # multiLineStringExpr
     | SINGLE_LINE_CHARLIST                                         # singleLineCharlistExpr
     | MULTI_LINE_CHARLIST                                          # multiLineCharlistExpr
     | ALIAS                                                        # aliasExpr
-    | CODEPOINT                                                    # codepointExpr
     | NIL                                                          # nilExpr
     ;
 


### PR DESCRIPTION
The modifier parsing was optimized by reducing the number of language syntaxes necessary to parse the content. Since the modifiers are represented as an Elixir map, the syntax for `if`, `else`, `for`, `case`, `try`, `catch`, function calls, math expressions, bit operations, etc., were removed. 